### PR TITLE
Fix forward ref

### DIFF
--- a/apps/web/app/routes/test-examples/field-with-ref.tsx
+++ b/apps/web/app/routes/test-examples/field-with-ref.tsx
@@ -14,12 +14,12 @@ import { useRef } from 'react'
 
 const title = 'Custom input with forward ref'
 const description =
-  "In this example, we use a forward ref to create a stateful tag list."
+  'In this example, we use a forward ref to create a stateful tag list.'
 
 export const meta: MetaFunction = () => metaTags({ title, description })
 
 const schema = z.object({
-  tags: z.array(z.string().min(1)).min(1)
+  tags: z.array(z.string().min(1)).min(1),
 })
 
 export const loader: LoaderFunction = () => ({
@@ -56,7 +56,7 @@ export default function Component() {
                     <Input
                       className="block w-full rounded-md border-gray-300 text-gray-800 shadow-sm focus:border-pink-500 focus:ring-pink-500 sm:text-sm"
                       type="text"
-                      name="tagName"
+                      name="oneTag"
                       ref={tagRef}
                       onKeyDown={(event) => {
                         if (event.key === 'Enter') {
@@ -64,7 +64,7 @@ export default function Component() {
                           if (tagRef.current) {
                             const value = tagRef.current.value
                             if (value) {
-                              setValue('tags', [...tags || [], value])
+                              setValue('tags', [...(tags || []), value])
                             }
                             tagRef.current.value = ''
                           }

--- a/apps/web/app/routes/test-examples/field-with-ref.tsx
+++ b/apps/web/app/routes/test-examples/field-with-ref.tsx
@@ -1,0 +1,95 @@
+import hljs from 'highlight.js/lib/common'
+import type {
+  ActionFunction,
+  LoaderFunction,
+  MetaFunction,
+} from '@remix-run/node'
+import { formAction } from '~/formAction'
+import { z } from 'zod'
+import Form from '~/ui/form'
+import { metaTags } from '~/helpers'
+import { makeDomainFunction } from 'domain-functions'
+import Example from '~/ui/example'
+import { useRef } from 'react'
+
+const title = 'Custom input with forward ref'
+const description =
+  "In this example, we use a forward ref to create a stateful tag list."
+
+export const meta: MetaFunction = () => metaTags({ title, description })
+
+const schema = z.object({
+  tags: z.array(z.string().min(1)).min(1)
+})
+
+export const loader: LoaderFunction = () => ({
+  code: hljs.highlight('', { language: 'ts' }).value,
+})
+
+const mutation = makeDomainFunction(schema)(async (values) => values)
+
+export const action: ActionFunction = async ({ request }) =>
+  formAction({ request, schema, mutation })
+
+export default function Component() {
+  const tagRef = useRef<HTMLInputElement>(null)
+  return (
+    <Example
+      title={title}
+      description={
+        <>
+          In this example, we use a forwardRef to feed tags from the form into
+          an array field.
+        </>
+      }
+    >
+      <Form schema={schema} values={{ tags: [] }}>
+        {({ Field, Errors, Button, setValue, watch }) => {
+          const tags = watch('tags')
+
+          return (
+            <>
+              <Field name="tags">
+                {({ Label, Errors, Input }) => (
+                  <>
+                    <Label />
+                    <Input
+                      className="block w-full rounded-md border-gray-300 text-gray-800 shadow-sm focus:border-pink-500 focus:ring-pink-500 sm:text-sm"
+                      type="text"
+                      name="tagName"
+                      ref={tagRef}
+                      onKeyDown={(event) => {
+                        if (event.key === 'Enter') {
+                          event.preventDefault()
+                          if (tagRef.current) {
+                            const value = tagRef.current.value
+                            if (value) {
+                              setValue('tags', [...tags || [], value])
+                            }
+                            tagRef.current.value = ''
+                          }
+                        }
+                      }}
+                    />
+                    <ul className="list-disc">
+                      {tags &&
+                        tags.map((tag) => (
+                          <li key={tag}>
+                            {tag}
+                            <input type="hidden" name="tags[]" value={tag} />
+                          </li>
+                        ))}
+                    </ul>
+                    <Errors />
+                  </>
+                )}
+              </Field>
+              <Errors />
+              <Button />
+            </>
+          )
+        }}
+      </Form>
+    </Example>
+  )
+}

--- a/apps/web/tests/examples/forms/field-with-ref.spec.ts
+++ b/apps/web/tests/examples/forms/field-with-ref.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from 'tests/setup/tests'
+
+const route = '/test-examples/field-with-ref'
+
+test('With JS enabled', async ({ example }) => {
+  const { button, page } = example
+
+  await page.goto(route)
+  const tags = example.field('oneTag')
+
+  // Client-side validation
+  await button.click()
+
+  // Show field errors and focus on the first field
+  await example.expectErrorMessage(
+    'tags',
+    'Array must contain at least 1 element(s)',
+  )
+
+  await expect(tags.input).toBeFocused()
+
+  await tags.input.fill('some tag')
+  await tags.input.press('Enter')
+
+  // Submit form
+  button.click()
+  await expect(button).toBeDisabled()
+  await example.expectData({ tags: ['some tag'] })
+})

--- a/packages/remix-forms/src/coercions.ts
+++ b/packages/remix-forms/src/coercions.ts
@@ -1,7 +1,5 @@
 import type { inputFromForm } from 'domain-functions'
 import type { ZodTypeAny } from 'zod'
-import { parseDate } from './prelude'
-import type { ShapeInfo } from './shapeInfo'
 import { shapeInfo } from './shapeInfo'
 
 type ParsedQs = Awaited<ReturnType<typeof inputFromForm>>
@@ -65,17 +63,4 @@ function coerceValue(value: Value, shape?: ZodTypeAny) {
   return value
 }
 
-function coerceToForm(value: unknown, shape: ShapeInfo) {
-  const { typeName } = shape
-  if (typeName === 'ZodBoolean') {
-    return Boolean(value) ?? false
-  }
-
-  if (typeName === 'ZodDate') {
-    return parseDate(value as Date | undefined)
-  }
-
-  return String(value ?? '')
-}
-
-export { coerceValue, coerceToForm }
+export { coerceValue }

--- a/packages/remix-forms/src/createField.tsx
+++ b/packages/remix-forms/src/createField.tsx
@@ -426,7 +426,7 @@ function createField<Schema extends SomeZodObject>({
               ...child.props,
               ref: mergedRef,
             })
-          } else if (child.type === Checkbox) {
+          } else if (child.type === Checkbox && (child.type !== 'input' || child.props.type === 'checkbox')) {
             return React.cloneElement(child, {
               id: String(name),
               type,

--- a/packages/remix-forms/src/createField.tsx
+++ b/packages/remix-forms/src/createField.tsx
@@ -313,7 +313,7 @@ function createField<Schema extends SomeZodObject>({
       const style = hidden ? { display: 'none' } : undefined
       const type = typeProp ?? getInputType(fieldType, radio)
 
-      const registerProps = register(String(name), {
+      const { ref: registerRef, ...registerProps } = register(String(name), {
         setValueAs: (value) => coerceValue(value, shape),
       })
 
@@ -362,6 +362,14 @@ function createField<Schema extends SomeZodObject>({
         })
 
         const children = mapChildren(childrenDefinition, (child) => {
+          const mergedRef = (instance: unknown) => {
+            registerRef(instance)
+            const { ref: childRef } = child as any
+            if (childRef) {
+              childRef.current = instance
+            }
+          }
+
           if (child.type === Label) {
             return React.cloneElement(child, {
               id: labelId,
@@ -377,11 +385,12 @@ function createField<Schema extends SomeZodObject>({
               multiline,
               radio,
               placeholder,
-              registerProps,
+              registerProps: { ...registerProps, ref: registerRef },
               autoFocus,
               value,
               a11yProps,
               ...child.props,
+              ref: mergedRef,
             })
           } else if (child.type === Input) {
             return React.cloneElement(child, {
@@ -393,6 +402,7 @@ function createField<Schema extends SomeZodObject>({
               autoFocus,
               defaultValue: value,
               ...child.props,
+              ref: mergedRef,
             })
           } else if (child.type === Multiline) {
             return React.cloneElement(child, {
@@ -403,6 +413,7 @@ function createField<Schema extends SomeZodObject>({
               autoFocus,
               defaultValue: value,
               ...child.props,
+              ref: mergedRef,
             })
           } else if (child.type === Select) {
             return React.cloneElement(child, {
@@ -413,6 +424,7 @@ function createField<Schema extends SomeZodObject>({
               defaultValue: value,
               children: makeOptionComponents(makeSelectOption, options),
               ...child.props,
+              ref: mergedRef,
             })
           } else if (child.type === Checkbox) {
             return React.cloneElement(child, {
@@ -424,6 +436,7 @@ function createField<Schema extends SomeZodObject>({
               placeholder,
               defaultChecked: Boolean(value),
               ...child.props,
+              ref: mergedRef,
             })
           } else if (child.type === RadioGroup) {
             return React.cloneElement(child, {
@@ -438,6 +451,7 @@ function createField<Schema extends SomeZodObject>({
               ...registerProps,
               defaultChecked: value === child.props.value,
               ...child.props,
+              ref: mergedRef,
             })
           } else if (child.type === Errors) {
             if (!child.props.children && !errors?.length) return null
@@ -497,7 +511,7 @@ function createField<Schema extends SomeZodObject>({
           multiline={multiline}
           radio={radio}
           placeholder={placeholder}
-          registerProps={registerProps}
+          registerProps={{ ref: registerRef, ...registerProps }}
           autoFocus={autoFocus}
           value={value}
           a11yProps={a11yProps}

--- a/packages/remix-forms/src/createField.tsx
+++ b/packages/remix-forms/src/createField.tsx
@@ -443,7 +443,7 @@ function createField<Schema extends SomeZodObject>({
               ...a11yProps,
               ...child.props,
             })
-          } else if (child.type === Radio) {
+          } else if (child.type === Radio && (child.type !== 'input' || child.props.type === 'radio')) {
             return React.cloneElement(child, {
               id: `${String(name)}-${child.props.value}`,
               type: 'radio',

--- a/packages/remix-forms/src/createForm.tsx
+++ b/packages/remix-forms/src/createForm.tsx
@@ -146,7 +146,7 @@ function coerceToForm(value: unknown, shape: ShapeInfo) {
     return parseDate(value as Date | undefined)
   }
 
-  if (typeName === 'ZodEnum' || typeName === 'ZodString') {
+  if (typeName === 'ZodEnum' || typeName === 'ZodString' || typeName === 'ZodNumber') {
     return String(value ?? '')
   }
 

--- a/packages/remix-forms/src/createForm.tsx
+++ b/packages/remix-forms/src/createForm.tsx
@@ -29,7 +29,8 @@ import { defaultRenderField } from './defaultRenderField'
 import { inferLabel } from './inferLabel'
 import type { ZodTypeName } from './shapeInfo'
 import { shapeInfo } from './shapeInfo'
-import { coerceToForm } from './coercions'
+import type { ShapeInfo } from './shapeInfo'
+import { parseDate } from './prelude'
 
 type FormMethod = 'get' | 'post' | 'put' | 'patch' | 'delete'
 
@@ -133,6 +134,23 @@ const fieldTypes: Record<ZodTypeName, FieldType> = {
   ZodBoolean: 'boolean',
   ZodDate: 'date',
   ZodEnum: 'string',
+}
+
+function coerceToForm(value: unknown, shape: ShapeInfo) {
+  const { typeName } = shape
+  if (typeName === 'ZodBoolean') {
+    return Boolean(value) ?? false
+  }
+
+  if (typeName === 'ZodDate') {
+    return parseDate(value as Date | undefined)
+  }
+
+  if (typeName === 'ZodEnum' || typeName === 'ZodString') {
+    return String(value ?? '')
+  }
+
+  return value ?? '';
 }
 
 function createForm({
@@ -272,11 +290,10 @@ function createForm({
 
     const fieldErrors = (key: keyof SchemaType) => {
       const message = (formErrors[key] as unknown as FieldError)?.message
-      return browser() ? (message && [message]) : (errors && errors[key])
+      return browser() ? message && [message] : errors && errors[key]
     }
-    const firstErroredField = () => Object.keys(schemaShape).find(
-      (key) => fieldErrors(key)?.length,
-    )
+    const firstErroredField = () =>
+      Object.keys(schemaShape).find((key) => fieldErrors(key)?.length)
     const makeField = (key: string) => {
       const shape = schemaShape[key]
       const { typeName, optional, nullable, enumValues } = shapeInfo(shape)
@@ -451,15 +468,15 @@ function createForm({
 
     React.useEffect(() => {
       Object.keys(errors).forEach((key) => {
-        form.setError(
-          key as Path<TypeOf<Schema>>,
-          { type: 'custom', message: (errors[key] as string[]).join(", ") }
-        )
+        form.setError(key as Path<TypeOf<Schema>>, {
+          type: 'custom',
+          message: (errors[key] as string[]).join(', '),
+        })
       })
       if (firstErroredField()) {
         try {
           form.setFocus(firstErroredField() as Path<SchemaType>)
-        } catch { }
+        } catch {}
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [errorsProp, unparsedActionData])


### PR DESCRIPTION
This PR ensures that any ref attribute used in a field `childrenFn` definition will be preserved, allowing custom inputs to carry imperative scripts.

It will also fix a bug where array fields are mistakenly coerced to strings. 

- Inline coerceToForm since it has only one call site and it seems very specific. We also avoid coercing shapes that we don't know (the catch all was coercing types such as ZodArray that are not showing up in the types)
- Merge forward ref from react-hook-form with refs that were found in the childrenFn definition so we do not override any custom imperative code from the user and keep RHF validations working.