### PR TITLE
Fix flaky specs

### DIFF
--- a/apps/web/tests/examples/forms/edit-values.spec.ts
+++ b/apps/web/tests/examples/forms/edit-values.spec.ts
@@ -18,13 +18,12 @@ test('With JS enabled', async ({ example }) => {
   await expect(options.first()).toHaveText('From A Friend')
   await expect(options.last()).toHaveText('Google')
 
-  await expect(await page.isChecked('input[type=checkbox]:visible')).toBeFalsy()
+  expect(await page.isChecked('input[type=checkbox]:visible')).toBeFalsy()
 
   await expect(button).toBeEnabled()
 
   // Submit form
   button.click()
-  await expect(button).toBeDisabled()
 
   await example.expectData({
     firstName: 'Mary',

--- a/apps/web/tests/examples/forms/radio-buttons.spec.ts
+++ b/apps/web/tests/examples/forms/radio-buttons.spec.ts
@@ -44,7 +44,6 @@ test('With JS enabled', async ({ example }) => {
 
 testWithoutJS('With JS disabled', async ({ example }) => {
   const { button, page } = example
-  const role = example.field('role')
 
   await page.goto(route)
 
@@ -59,15 +58,16 @@ testWithoutJS('With JS disabled', async ({ example }) => {
   await button.click()
 
   // Show field errors and focus on the first field
+  await expect(
+    example.page.locator(`[data-headlessui-state="open"] #errors-for-role:visible`),
+  ).toHaveText("Invalid enum value. Expected 'Designer' | 'Dev', received ''")
 
-  await example.expectErrorMessage(
-    'role',
-    "Invalid enum value. Expected 'Designer' | 'Dev', received ''",
-  )
+  const designerRadio = example.page.locator('[data-headlessui-state="open"] [name="role"][value="Designer"]:visible')
 
-  await expect(role.input.first()).toBeFocused()
+  await example.page.waitForLoadState('networkidle')
+  await expect(designerRadio).toBeFocused()
 
-  await role.input.first().click()
+  await designerRadio.click()
 
   // Submit form
   await button.click()


### PR DESCRIPTION
The expectation on the button disabled is failing under certain conditions even if the behaviour is working properly.
Later we can reimplement those assertions using MutationObservers but that will be more work-intensive, so the current PR just removes the worst offender (the one in edit-value spec).
