### PR TITLE
Unify Top Bars

### DIFF
--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -1,4 +1,4 @@
-import type { LinksFunction } from 'react-router'
+import type { LinksFunction, UIMatch } from 'react-router'
 import {
   Link,
   Links,
@@ -22,7 +22,17 @@ export const links: LinksFunction = () => {
 }
 
 export default function App({ matches }: Route.ComponentProps) {
-  const conf = matches.find((match) => match?.pathname.startsWith('/conf'))
+  const match = matches.find(
+    (match) => match?.handle && 'topBar' in (match.handle as any),
+  ) as UIMatch<unknown, { topBar: React.ReactNode }>
+  const secondTopBar = match?.handle.topBar || (
+    <ConfTopBar>
+      <Link to={'/conf'} className="underline">
+        Check out our talk
+      </Link>{' '}
+      at Remix Conf!
+    </ConfTopBar>
+  )
 
   return (
     <html lang="en" className="h-full overflow-x-hidden">
@@ -36,14 +46,7 @@ export default function App({ matches }: Route.ComponentProps) {
       <body className="flex min-h-screen w-screen max-w-[100vw] flex-col overflow-y-auto bg-gradient-to-r from-gray-900 to-gray-600 antialiased overflow-x-hidden scrollbar-thin scrollbar-track-gray-500 scrollbar-thumb-gray-700">
         <GlobalLoading />
         <TopBar />
-        {!conf && (
-          <ConfTopBar>
-            <Link to={'/conf'} className="underline">
-              Check out our talk
-            </Link>{' '}
-            at Remix Conf!
-          </ConfTopBar>
-        )}
+        {secondTopBar}
         <main className="flex flex-1 flex-col">
           <Outlet />
         </main>

--- a/apps/web/app/routes/conf/layout.tsx
+++ b/apps/web/app/routes/conf/layout.tsx
@@ -47,25 +47,6 @@ export default function Component({ matches }: Route.ComponentProps) {
           </SidebarLayout.NavLink>
         </SidebarLayout.Nav>
         <SidebarLayout.Content>
-          <TopBar>
-            <div className="hidden flex-1 lg:block">
-              This is the{' '}
-              <Link to={'/conf'} className="underline">
-                interactive counterpart
-              </Link>{' '}
-              to our talk at Remix Conf 2022.{' '}
-              <ExternalLink href="https://docs.google.com/presentation/d/1Mp961HsJD9qVElS5VD-szYJ9CkZhnVjJBwMfUahwwek/edit#slide=id.p">
-                Get the full slides
-              </ExternalLink>
-              .
-            </div>
-            <div className="flex-1 lg:hidden">
-              <ExternalLink href="https://docs.google.com/presentation/d/1Mp961HsJD9qVElS5VD-szYJ9CkZhnVjJBwMfUahwwek/edit#slide=id.p">
-                Get the full slides
-              </ExternalLink>
-              .
-            </div>
-          </TopBar>
           <div className="flex flex-col space-y-4 p-4 text-gray-200 sm:space-y-8 sm:p-8">
             <Outlet />
           </div>
@@ -89,4 +70,28 @@ export default function Component({ matches }: Route.ComponentProps) {
       </SidebarLayout>
     </div>
   )
+}
+
+export const handle = {
+  topBar: (
+    <TopBar>
+      <div className="hidden flex-1 lg:block">
+        This is the{' '}
+        <Link to={'/conf'} className="underline">
+          interactive counterpart
+        </Link>{' '}
+        to our talk at Remix Conf 2022.{' '}
+        <ExternalLink href="https://docs.google.com/presentation/d/1Mp961HsJD9qVElS5VD-szYJ9CkZhnVjJBwMfUahwwek/edit#slide=id.p">
+          Get the full slides
+        </ExternalLink>
+        .
+      </div>
+      <div className="flex-1 lg:hidden">
+        <ExternalLink href="https://docs.google.com/presentation/d/1Mp961HsJD9qVElS5VD-szYJ9CkZhnVjJBwMfUahwwek/edit#slide=id.p">
+          Get the full slides
+        </ExternalLink>
+        .
+      </div>
+    </TopBar>
+  ),
 }


### PR DESCRIPTION
By using `handle` to override the root topbar we'll have them at the same position keeping consistent layout across all pages.

# Before
![screen](https://github.com/user-attachments/assets/6911376c-b58f-4403-9d88-0658dfad3dec)

# After
![screen2](https://github.com/user-attachments/assets/d4fe3d47-dfcc-4db4-896c-3ed7955b5bf1)