### PR TITLE
Use actions/upload-artifacts@v4 to avoid deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: npm run build
       - name: Run Playwright tests
         run: npm run test
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-report


### PR DESCRIPTION
FYI: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/