### PR TITLE
Return full result on formAction with 422 status for failure

### DIFF
--- a/apps/web/app/routes/examples/custom-response.spec.ts
+++ b/apps/web/app/routes/examples/custom-response.spec.ts
@@ -43,7 +43,12 @@ test('With JS enabled', async ({ example }) => {
   // Submit form
   button.click()
   await expect(button).toBeDisabled()
-  await example.expectData({ customName: 'John' })
+
+  const actionData = JSON.parse(
+    await page.locator('#action-data > pre:visible').first().innerText(),
+  )
+
+  expect(actionData).toEqual({ customName: 'John' })
 })
 
 testWithoutJS('With JS disabled', async ({ example }) => {
@@ -90,5 +95,10 @@ testWithoutJS('With JS disabled', async ({ example }) => {
   // Submit form
   await button.click()
   await page.reload()
-  await example.expectData({ customName: 'John' })
+
+  const actionData = JSON.parse(
+    await page.locator('#action-data > pre:visible').first().innerText(),
+  )
+
+  expect(actionData).toEqual({ customName: 'John' })
 })

--- a/apps/web/tests/setup/example.ts
+++ b/apps/web/tests/setup/example.ts
@@ -164,7 +164,7 @@ class Example {
       await this.page.locator('#action-data > pre:visible').first().innerText(),
     )
 
-    expect(actionData).toEqual(data)
+    expect(actionData.data).toEqual(data)
   }
 }
 


### PR DESCRIPTION
### formAction always returns the mutation result

Now we always return the full `MutationResult` on `formAction`. If you use `formAction` without a `sucessPath` and manually get the action data in your components, you'll have to check for `success` first and only then access the mutation result inside `data`:

```tsx
export const action = async ({ request }: Route.ActionArgs) =>
  formAction({ request, schema, mutation })

export default function Component({ actionData }: Route.ComponentProps) {
  if (!actionData) {
    return <p>Our action has not run yet.</p>
  }

  if (!actionData.success) {
    return (
      <div>
        <h3>Errors:</h3>
        <pre>{JSON.stringify(actionData.errors, null, 2)}</pre>
        <h3>Values:</h3>
        <pre>{JSON.stringify(actionData.values, null, 2)}</pre>
      </div>
    )
  }

  return (
    <div>
      <h3>Data:</h3>
      <pre>{JSON.stringify(actionData.data, null, 2)}</pre>
    </div>
  )
}
```

### formAction returns 422 status on failed mutations

To avoid revalidating loaders unnecessarily, `formAction` now returns a 422 status on failed mutations.