### PR TITLE
Add tests for shapeInfo

### DIFF
--- a/packages/remix-forms/src/shape-info.test.ts
+++ b/packages/remix-forms/src/shape-info.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import * as z from 'zod'
+import { shapeInfo } from './shape-info'
+
+describe('shapeInfo', () => {
+  it('returns null type when shape is undefined', () => {
+    expect(shapeInfo()).toEqual({
+      typeName: null,
+      optional: false,
+      nullable: false,
+      getDefaultValue: undefined,
+      enumValues: undefined,
+    })
+  })
+
+  it('extracts info from primitive shapes', () => {
+    expect(shapeInfo(z.string())).toEqual({
+      typeName: 'ZodString',
+      optional: false,
+      nullable: false,
+      getDefaultValue: undefined,
+      enumValues: undefined,
+    })
+  })
+
+  it('marks optional and nullable shapes correctly', () => {
+    const info = shapeInfo(z.number().optional().nullable())
+    expect(info).toEqual({
+      typeName: 'ZodNumber',
+      optional: true,
+      nullable: true,
+      getDefaultValue: undefined,
+      enumValues: undefined,
+    })
+  })
+
+  it('collects default value getter', () => {
+    const info = shapeInfo(z.string().default('foo'))
+    expect(info.typeName).toBe('ZodString')
+    expect(typeof info.getDefaultValue).toBe('function')
+    expect(info.getDefaultValue?.()).toBe('foo')
+  })
+
+  it('unwraps nested shapes and effects', () => {
+    const shape = z
+      .string()
+      .default('bar')
+      .optional()
+      .nullable()
+      .transform((v) => v)
+    const info = shapeInfo(shape)
+    expect(info.typeName).toBe('ZodString')
+    expect(info.optional).toBe(true)
+    expect(info.nullable).toBe(true)
+    expect(info.getDefaultValue?.()).toBe('bar')
+  })
+
+  it('returns enum values', () => {
+    const info = shapeInfo(z.enum(['a', 'b']))
+    expect(info).toEqual({
+      typeName: 'ZodEnum',
+      optional: false,
+      nullable: false,
+      getDefaultValue: undefined,
+      enumValues: ['a', 'b'],
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add unit tests for `shapeInfo`

## Testing
- `npx turbo run test --filter=remix-forms`
