### PR TITLE
Add TSDoc for public API

### DIFF
--- a/packages/remix-forms/src/create-field.tsx
+++ b/packages/remix-forms/src/create-field.tsx
@@ -148,6 +148,22 @@ const FieldContext = React.createContext<
   Partial<Omit<Field<never>, 'name'>> | undefined
 >(undefined)
 
+/**
+ * Access information about the currently rendered field inside custom
+ * components.
+ *
+ * @returns Data describing the field being rendered
+ *
+ * @example
+ * ```tsx
+ * const { label } = useField()
+ * ```
+ *
+ * @example
+ * ```tsx
+ * const { errors } = useField()
+ * ```
+ */
 export function useField() {
   const context = React.useContext(FieldContext)
 

--- a/packages/remix-forms/src/mutations.ts
+++ b/packages/remix-forms/src/mutations.ts
@@ -82,6 +82,20 @@ type FormErrors<SchemaType> = Partial<
   Record<keyof SchemaType | '_global', string[]>
 >
 
+/**
+ * Result of a mutation executed by {@link performMutation} or
+ * {@link formAction}.
+ *
+ * @example
+ * ```ts
+ * if (result.success) console.log(result.data)
+ * ```
+ *
+ * @example
+ * ```ts
+ * if (!result.success) console.log(result.errors)
+ * ```
+ */
 type MutationResult<SchemaType, D> =
   | ({ success: false } & FormActionFailure<SchemaType>)
   | { success: true; data: D }
@@ -99,6 +113,22 @@ type PerformMutationProps<Schema extends FormSchema, D> = {
   ) => MutationResult<Schema, D> | Promise<MutationResult<Schema, D>>
 }
 
+/**
+ * Options for {@link formAction}.
+ *
+ * In addition to {@link PerformMutationProps} this allows specifying a path
+ * to redirect to when the mutation succeeds.
+ *
+ * @example
+ * ```ts
+ * formAction({ request, schema, mutation, successPath: '/done' })
+ * ```
+ *
+ * @example
+ * ```ts
+ * formAction({ request, schema, mutation })
+ * ```
+ */
 type FormActionProps<Schema extends FormSchema, D> = {
   successPath?: ((data: D) => string | Promise<string>) | string
 } & PerformMutationProps<Schema, D>
@@ -120,6 +150,22 @@ async function getFormValues<Schema extends FormSchema>(
   return values
 }
 
+/**
+ * Execute a mutation with values from a form request.
+ *
+ * @param options - Configuration for how the mutation is run
+ * @returns The mutation result with success flag and data or errors
+ *
+ * @example
+ * ```ts
+ * const result = await performMutation({ request, schema, mutation })
+ * ```
+ *
+ * @example
+ * ```ts
+ * performMutation({ request, schema, mutation, context: { user } })
+ * ```
+ */
 async function performMutation<Schema extends FormSchema, D>({
   request,
   schema,
@@ -151,6 +197,22 @@ async function performMutation<Schema extends FormSchema, D>({
   })
 }
 
+/**
+ * Remix action helper that runs a mutation and handles redirects.
+ *
+ * @param options - Mutation options plus an optional success redirect path
+ * @returns A response created with `data()` containing the mutation result
+ *
+ * @example
+ * ```ts
+ * export const action = () => formAction({ request, schema, mutation })
+ * ```
+ *
+ * @example
+ * ```ts
+ * formAction({ request, schema, mutation, successPath: '/thanks' })
+ * ```
+ */
 async function formAction<Schema extends FormSchema, D>({
   successPath,
   ...performMutationOptions

--- a/packages/remix-forms/src/prelude.ts
+++ b/packages/remix-forms/src/prelude.ts
@@ -1,5 +1,23 @@
 import type { z } from 'zod'
 
+/**
+ * Zod schema accepted by remix-forms components and utilities.
+ *
+ * This type covers plain objects as well as Zod effects so you can pass
+ * schemas created with refinements or preprocessors.
+ *
+ * @example
+ * ```ts
+ * const schema = z.object({ name: z.string() })
+ * type MySchema = FormSchema<typeof schema>
+ * ```
+ *
+ * @example
+ * ```ts
+ * const schema = z.object({ age: z.number() }).transform((d) => ({ ...d, ok: true }))
+ * type MySchema = FormSchema<typeof schema>
+ * ```
+ */
 // biome-ignore lint/suspicious/noExplicitAny: <explanation>
 type FormSchema<T extends z.ZodTypeAny = z.SomeZodObject | z.ZodEffects<any>> =
   | z.ZodEffects<T>

--- a/packages/remix-forms/src/schema-form.tsx
+++ b/packages/remix-forms/src/schema-form.tsx
@@ -58,10 +58,39 @@ type Field<SchemaType> = {
   placeholder?: string
 }
 
+/**
+ * Props passed to a custom field rendering component.
+ *
+ * The `Field` component is provided so callers can easily render individual
+ * fields using the same mappings as `SchemaForm`.
+ *
+ * @example
+ * ```tsx
+ * const MyField = ({ Field, name }) => <Field name={name} />
+ * ```
+ *
+ * @example
+ * ```tsx
+ * const MyField = ({ errors }) => <span>{errors?.join(',')}</span>
+ * ```
+ */
 type RenderFieldProps<Schema extends SomeZodObject> = Field<z.infer<Schema>> & {
   Field: FieldComponent<Schema>
 }
 
+/**
+ * Function signature used for rendering form fields.
+ *
+ * @example
+ * ```tsx
+ * const renderField = ({ Field, ...props }) => <Field {...props} />
+ * ```
+ *
+ * @example
+ * ```tsx
+ * const renderField = ({ name }) => <input name={String(name)} />
+ * ```
+ */
 type RenderField<Schema extends SomeZodObject> = (
   props: RenderFieldProps<Schema>
 ) => JSX.Element
@@ -84,6 +113,22 @@ type OnNavigation<Schema extends SomeZodObject> = (
   helpers: UseFormReturn<z.infer<Schema>, any>
 ) => void
 
+/**
+ * Props for the {@link SchemaForm} component.
+ *
+ * These options control how the form is rendered and how values and errors
+ * are populated.
+ *
+ * @example
+ * ```tsx
+ * <SchemaForm schema={schema} />
+ * ```
+ *
+ * @example
+ * ```tsx
+ * <SchemaForm schema={schema} renderField={({ Field, ...f }) => <Field {...f} />} />
+ * ```
+ */
 type SchemaFormProps<Schema extends FormSchema> = ComponentMappings & {
   component?: typeof ReactRouterForm
   // biome-ignore lint/suspicious/noExplicitAny: <explanation>
@@ -147,6 +192,25 @@ function coerceToForm(value: unknown, shape: ShapeInfo) {
   return value ?? ''
 }
 
+/**
+ * Render a form based on a Zod schema.
+ *
+ * This component automatically wires up inputs with React Hook Form and
+ * handles client-side validation.
+ *
+ * @param props - Options describing the form structure and behavior
+ * @returns A form element ready to be used inside a Remix route
+ *
+ * @example
+ * ```tsx
+ * <SchemaForm schema={schema} />
+ * ```
+ *
+ * @example
+ * ```tsx
+ * <SchemaForm schema={schema} fetcher={useFetcher()} />
+ * ```
+ */
 function SchemaForm<Schema extends FormSchema>({
   component = ReactRouterForm,
   fetcher,


### PR DESCRIPTION
## Summary
- document `FormSchema` in `prelude`
- add TSDoc for `RenderFieldProps`, `RenderField`, `SchemaFormProps` and `SchemaForm`
- document `useField`
- document mutation helpers and types

## Testing
- `npm run lint`
- `npm run tsc`
- `npm run test`
