### PR TITLE
Add unit tests for helpers

### DIFF
--- a/packages/remix-forms/src/children-traversal.test.tsx
+++ b/packages/remix-forms/src/children-traversal.test.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react'
+import { describe, expect, it } from 'vitest'
+import {
+  findElement,
+  findParent,
+  mapChildren,
+  reduceElements,
+} from './children-traversal'
+
+describe('mapChildren', () => {
+  it('applies the mapper to all elements recursively', () => {
+    const tree = (
+      <div>
+        <span>A</span>
+        <div>
+          <p>B</p>
+        </div>
+      </div>
+    )
+
+    const mapped = mapChildren(tree, (child) =>
+      React.cloneElement(child, { 'data-mapped': true })
+    ) as React.ReactElement[]
+
+    const root = mapped[0]
+    expect(root.props['data-mapped']).toBe(true)
+    const innerDiv = root.props.children[1]
+    expect(innerDiv.props['data-mapped']).toBe(true)
+    const innerP = innerDiv.props.children[0]
+    expect(innerP.props['data-mapped']).toBe(true)
+  })
+})
+
+describe('reduceElements', () => {
+  it('reduces all valid React elements', () => {
+    const tree = (
+      <div>
+        <span>A</span>
+        <p>B</p>
+      </div>
+    )
+    const count = reduceElements(tree, 0, (acc) => acc + 1)
+    expect(count).toBe(3)
+  })
+})
+
+describe('findElement and findParent', () => {
+  it('locates elements and their parents within a tree', () => {
+    const child = (
+      <span key="c" id="child">
+        C
+      </span>
+    )
+    const tree = (
+      <div>
+        <section>{[child]}</section>
+      </div>
+    )
+
+    const found = findElement(tree, (el) => el.props.id === 'child')
+    expect(found).toBe(child)
+
+    const parent = findParent(tree, child)
+    expect(parent?.type).toBe('section')
+  })
+})

--- a/packages/remix-forms/src/default-render-field.test.tsx
+++ b/packages/remix-forms/src/default-render-field.test.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react'
+import { describe, expect, it } from 'vitest'
+import type * as z from 'zod'
+import type { FieldComponent } from './create-field'
+import { defaultRenderField } from './default-render-field'
+
+describe('defaultRenderField', () => {
+  it('renders the provided Field component with props and key', () => {
+    const Field = React.forwardRef<HTMLDivElement, Record<string, unknown>>(
+      (props, ref) => <div ref={ref} {...props} />
+    ) as unknown as FieldComponent<z.AnyZodObject>
+    // biome-ignore lint/suspicious/noExplicitAny: test helper casting
+    const element = (defaultRenderField as any)({
+      Field,
+      name: 'foo',
+      label: 'Foo',
+      // required Field properties for typing
+      shape: {} as never,
+      fieldType: 'string',
+      required: false,
+      dirty: false,
+      // biome-ignore lint/suspicious/noExplicitAny: partial props for simplicity
+    } as any)
+    expect(element.key).toBe('foo')
+    expect(element.type).toBe(Field)
+    expect(element.props.name).toBe('foo')
+    expect(element.props.label).toBe('Foo')
+  })
+})

--- a/packages/remix-forms/src/prelude.test.ts
+++ b/packages/remix-forms/src/prelude.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import * as z from 'zod'
+import { browser, mapObject, objectFromSchema, parseDate } from './prelude'
+
+describe('objectFromSchema', () => {
+  it('returns the object when given a Zod object', () => {
+    const schema = z.object({ name: z.string() })
+    expect(objectFromSchema(schema)).toBe(schema)
+  })
+
+  it('unwraps Zod effects to return the inner object', () => {
+    const inner = z.object({ age: z.number() })
+    const schema = z.preprocess((v) => v, inner)
+    expect(objectFromSchema(schema)).toBe(inner)
+  })
+})
+
+describe('mapObject', () => {
+  it('maps each key/value pair using the provided function', () => {
+    const obj: Record<string, number> = { a: 1, b: 2 }
+    const result = mapObject<Record<string, number>, number, number>(
+      obj,
+      (key, value) => [key + key, value * 2]
+    )
+    expect(result).toEqual({ aa: 2, bb: 4 })
+  })
+})
+
+describe('parseDate', () => {
+  it('returns undefined when value is falsy', () => {
+    expect(parseDate()).toBeUndefined()
+  })
+
+  it('formats Date instances as YYYY-MM-DD strings', () => {
+    const date = new Date('2024-01-02T10:20:30Z')
+    expect(parseDate(date)).toBe('2024-01-02')
+  })
+
+  it('passes through date strings unchanged', () => {
+    expect(parseDate('2024-05-06T07:08:09Z')).toBe('2024-05-06')
+  })
+})
+
+describe('browser', () => {
+  const original = globalThis.document
+  afterEach(() => {
+    // restore original document
+    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+    ;(globalThis as any).document = original
+  })
+
+  it('returns false when document is undefined', () => {
+    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+    ;(globalThis as any).document = undefined
+    expect(browser()).toBe(false)
+  })
+
+  it('returns true when document is defined', () => {
+    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+    ;(globalThis as any).document = {}
+    expect(browser()).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- add tests covering `prelude` helpers
- add tests for `defaultRenderField`
- add tests for children traversal utilities

## Testing
- `npm run lint`
- `npm run tsc`
- `npx turbo run test --filter=remix-forms`
