### PR TITLE
Add docs for public API

### DIFF
--- a/packages/remix-forms/src/create-field.tsx
+++ b/packages/remix-forms/src/create-field.tsx
@@ -148,6 +148,22 @@ const FieldContext = React.createContext<
   Partial<Omit<Field<never>, 'name'>> | undefined
 >(undefined)
 
+/**
+ * Access information about the currently rendered field inside custom
+ * components.
+ *
+ * @returns Data describing the field being rendered
+ *
+ * @example
+ * ```tsx
+ * const { label } = useField()
+ * ```
+ *
+ * @example
+ * ```tsx
+ * const { errors } = useField()
+ * ```
+ */
 export function useField() {
   const context = React.useContext(FieldContext)
 

--- a/packages/remix-forms/src/mutations.ts
+++ b/packages/remix-forms/src/mutations.ts
@@ -82,6 +82,20 @@ type FormErrors<SchemaType> = Partial<
   Record<keyof SchemaType | '_global', string[]>
 >
 
+/**
+ * Result of a mutation executed by {@link performMutation} or
+ * {@link formAction}.
+ *
+ * @example
+ * ```ts
+ * if (result.success) console.log(result.data)
+ * ```
+ *
+ * @example
+ * ```ts
+ * if (!result.success) console.log(result.errors)
+ * ```
+ */
 type MutationResult<SchemaType, D> =
   | ({ success: false } & FormActionFailure<SchemaType>)
   | { success: true; data: D }
@@ -99,6 +113,27 @@ type PerformMutationProps<Schema extends FormSchema, D> = {
   ) => MutationResult<Schema, D> | Promise<MutationResult<Schema, D>>
 }
 
+/**
+ * Options for {@link formAction}.
+ *
+ * @property request - The HTTP request containing form data
+ * @property schema - Zod schema used to validate the values
+ * @property mutation - Function executed with the parsed values
+ * @property [context] - Extra context passed to the mutation
+ * @property [transformValues] - Modify values before calling the mutation
+ * @property [transformResult] - Modify the result before returning
+ * @property [successPath] - Path or function resolving the redirect location on success
+ *
+ * @example
+ * ```ts
+ * formAction({ request, schema, mutation, successPath: '/done' })
+ * ```
+ *
+ * @example
+ * ```ts
+ * formAction({ request, schema, mutation })
+ * ```
+ */
 type FormActionProps<Schema extends FormSchema, D> = {
   successPath?: ((data: D) => string | Promise<string>) | string
 } & PerformMutationProps<Schema, D>
@@ -120,6 +155,27 @@ async function getFormValues<Schema extends FormSchema>(
   return values
 }
 
+/**
+ * Execute a mutation with values from a form request.
+ *
+ * @param options.request - The incoming request with form data
+ * @param options.schema - Schema describing the form structure
+ * @param options.mutation - Function executed with the parsed values
+ * @param options.context - Context object forwarded to the mutation
+ * @param options.transformValues - Modify values before calling the mutation
+ * @param options.transformResult - Modify the result before returning
+ * @returns The mutation result with success flag and data or errors
+ *
+ * @example
+ * ```ts
+ * const result = await performMutation({ request, schema, mutation })
+ * ```
+ *
+ * @example
+ * ```ts
+ * performMutation({ request, schema, mutation, context: { user } })
+ * ```
+ */
 async function performMutation<Schema extends FormSchema, D>({
   request,
   schema,
@@ -151,6 +207,28 @@ async function performMutation<Schema extends FormSchema, D>({
   })
 }
 
+/**
+ * React Router v7 action helper that runs a mutation and handles redirects.
+ *
+ * @param options.request - The request to read form data from
+ * @param options.schema - Schema describing the expected form fields
+ * @param options.mutation - Function that performs the actual mutation
+ * @param options.context - Context object forwarded to the mutation
+ * @param options.transformValues - Map the form values before running the mutation
+ * @param options.transformResult - Map the mutation result before returning
+ * @param options.successPath - Path or function resolving the redirect location on success
+ * @returns A response created with `data()` containing the mutation result
+ *
+ * @example
+ * ```ts
+ * export const action = () => formAction({ request, schema, mutation })
+ * ```
+ *
+ * @example
+ * ```ts
+ * formAction({ request, schema, mutation, successPath: '/thanks' })
+ * ```
+ */
 async function formAction<Schema extends FormSchema, D>({
   successPath,
   ...performMutationOptions

--- a/packages/remix-forms/src/prelude.ts
+++ b/packages/remix-forms/src/prelude.ts
@@ -1,5 +1,23 @@
 import type { z } from 'zod'
 
+/**
+ * Zod schema accepted by remix-forms components and utilities.
+ *
+ * This type covers plain objects as well as Zod effects so you can pass
+ * schemas created with refinements or preprocessors.
+ *
+ * @example
+ * ```ts
+ * const schema = z.object({ name: z.string() })
+ * type MySchema = FormSchema<typeof schema>
+ * ```
+ *
+ * @example
+ * ```ts
+ * const schema = z.object({ age: z.number() }).transform((d) => ({ ...d, ok: true }))
+ * type MySchema = FormSchema<typeof schema>
+ * ```
+ */
 // biome-ignore lint/suspicious/noExplicitAny: <explanation>
 type FormSchema<T extends z.ZodTypeAny = z.SomeZodObject | z.ZodEffects<any>> =
   | z.ZodEffects<T>

--- a/packages/remix-forms/src/schema-form.tsx
+++ b/packages/remix-forms/src/schema-form.tsx
@@ -58,10 +58,39 @@ type Field<SchemaType> = {
   placeholder?: string
 }
 
+/**
+ * Props passed to a custom field rendering component.
+ *
+ * The `Field` component is provided so callers can easily render individual
+ * fields using the same mappings as `SchemaForm`.
+ *
+ * @example
+ * ```tsx
+ * const MyField = ({ Field, name }) => <Field name={name} />
+ * ```
+ *
+ * @example
+ * ```tsx
+ * const MyField = ({ errors }) => <span>{errors?.join(',')}</span>
+ * ```
+ */
 type RenderFieldProps<Schema extends SomeZodObject> = Field<z.infer<Schema>> & {
   Field: FieldComponent<Schema>
 }
 
+/**
+ * Function signature used for rendering form fields.
+ *
+ * @example
+ * ```tsx
+ * const renderField = ({ Field, ...props }) => <Field {...props} />
+ * ```
+ *
+ * @example
+ * ```tsx
+ * const renderField = ({ name }) => <input name={String(name)} />
+ * ```
+ */
 type RenderField<Schema extends SomeZodObject> = (
   props: RenderFieldProps<Schema>
 ) => JSX.Element
@@ -84,6 +113,22 @@ type OnNavigation<Schema extends SomeZodObject> = (
   helpers: UseFormReturn<z.infer<Schema>, any>
 ) => void
 
+/**
+ * Props for the {@link SchemaForm} component.
+ *
+ * These options control how the form is rendered and how values and errors
+ * are populated.
+ *
+ * @example
+ * ```tsx
+ * <SchemaForm schema={schema} />
+ * ```
+ *
+ * @example
+ * ```tsx
+ * <SchemaForm schema={schema} renderField={({ Field, ...f }) => <Field {...f} />} />
+ * ```
+ */
 type SchemaFormProps<Schema extends FormSchema> = ComponentMappings & {
   component?: typeof ReactRouterForm
   // biome-ignore lint/suspicious/noExplicitAny: <explanation>
@@ -147,6 +192,62 @@ function coerceToForm(value: unknown, shape: ShapeInfo) {
   return value ?? ''
 }
 
+/**
+ * Render a form based on a Zod schema.
+ *
+ * This component automatically wires up inputs with React Hook Form and
+ * handles client-side validation.
+ *
+ * @param props.component - Form component used for rendering
+ * @param props.fetcher - Fetcher object returned by `useFetcher()`
+ * @param props.mode - Validation trigger mode for React Hook Form
+ * @param props.reValidateMode - Validation mode after submission
+ * @param props.renderField - Custom field rendering function
+ * @param props.fieldComponent - Component used for each field container
+ * @param props.labelComponent - Component used for labels
+ * @param props.inputComponent - Component used for standard inputs
+ * @param props.multilineComponent - Component used for multiline inputs
+ * @param props.selectComponent - Component used for select inputs
+ * @param props.checkboxComponent - Component used for checkbox inputs
+ * @param props.radioComponent - Component used for radio inputs
+ * @param props.checkboxWrapperComponent - Wrapper around checkbox inputs
+ * @param props.radioGroupComponent - Wrapper around radio options
+ * @param props.radioWrapperComponent - Wrapper around individual radio inputs
+ * @param props.globalErrorsComponent - Component for rendering global errors
+ * @param props.fieldErrorsComponent - Component for rendering per-field errors
+ * @param props.errorComponent - Component for rendering error messages
+ * @param props.buttonComponent - Component used for the submit button
+ * @param props.buttonLabel - Text shown in the submit button
+ * @param props.pendingButtonLabel - Text shown while submitting
+ * @param props.method - HTTP method used to submit the form
+ * @param props.schema - Zod schema describing the form
+ * @param props.beforeChildren - Elements rendered before generated fields
+ * @param props.onNavigation - Callback when navigation state changes
+ * @param props.children - Custom content instead of the default layout
+ * @param props.labels - Custom labels for form fields
+ * @param props.placeholders - Placeholder text for fields
+ * @param props.options - Select and radio options for fields
+ * @param props.inputTypes - Custom input types per field
+ * @param props.hiddenFields - Fields rendered as hidden inputs
+ * @param props.multiline - Fields rendered with the multiline component
+ * @param props.radio - Fields rendered as radio groups
+ * @param props.autoFocus - Field that should receive focus initially
+ * @param props.errors - Error messages keyed by field name
+ * @param props.values - Initial values for fields
+ * @param props.emptyOptionLabel - Label for the empty select option
+ * @param props.flushSync - Whether to flush React updates synchronously
+ * @returns A form element ready to be used inside a React Router v7 route
+ *
+ * @example
+ * ```tsx
+ * <SchemaForm schema={schema} />
+ * ```
+ *
+ * @example
+ * ```tsx
+ * <SchemaForm schema={schema} fetcher={useFetcher()} />
+ * ```
+ */
 function SchemaForm<Schema extends FormSchema>({
   component = ReactRouterForm,
   fetcher,


### PR DESCRIPTION
## Summary
- expand documentation for `formAction` options
- describe `performMutation` parameters in detail
- document all `SchemaForm` props
- reference React Router v7 instead of Remix

## Testing
- `npm run lint`
- `npm run tsc`
- `npm run test` *(fails: HTML report served, requires manual shutdown)*