### PR TITLE
Fix failing tests

### DIFF
--- a/apps/web/app/routes/examples/imperative-submit.spec.ts
+++ b/apps/web/app/routes/examples/imperative-submit.spec.ts
@@ -10,9 +10,10 @@ test('With JS enabled', async ({ example }) => {
   await page.goto(route)
 
   await token.input.first().type('123')
-  expect(page.locator('#action-data > pre')).toBeHidden()
+  await expect(page.locator('#action-data > pre')).toBeHidden()
 
   await token.input.first().type('4')
+  await page.waitForLoadState('networkidle')
 
   await example.expectData({
     token: '1234',

--- a/apps/web/app/routes/examples/zod-effects.spec.ts
+++ b/apps/web/app/routes/examples/zod-effects.spec.ts
@@ -73,6 +73,7 @@ test('With JS enabled we see a refinement validation error', async ({
   // Submit
   await expect(button).toBeEnabled()
   await button.click()
+  await page.waitForLoadState('networkidle')
 
   await example.expectError(
     planType,

--- a/apps/web/tests/setup/example.ts
+++ b/apps/web/tests/setup/example.ts
@@ -112,7 +112,7 @@ class Example {
     await expect(field.input).toHaveAttribute('aria-invalid', 'true')
 
     await expect(field.input).toHaveAttribute(
-      'aria-describedBy',
+      'aria-describedby',
       `errors-for-${field.name}`
     )
   }


### PR DESCRIPTION
## Summary
- correct `aria-describedby` typo in test helper
- wait for page state in tests

## Testing
- `npm run lint`
- `npm run tsc`
- `npm run test` *(fails: command exited with 1)*