### PR TITLE
Add missing unit tests

### DIFF
--- a/packages/remix-forms/src/create-field.test.tsx
+++ b/packages/remix-forms/src/create-field.test.tsx
@@ -1,0 +1,58 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import type { UseFormRegister } from 'react-hook-form'
+import { describe, expect, it, vi } from 'vitest'
+import { createField, useField } from './create-field'
+
+const register = vi.fn(() => ({
+  name: 'foo',
+  onChange: () => Promise.resolve(),
+  onBlur: () => Promise.resolve(),
+  ref: () => {},
+})) as unknown as UseFormRegister<Record<string, unknown>>
+import * as z from 'zod'
+
+const schema = z.object({ foo: z.string() })
+const Field = createField<typeof schema>({ register })
+
+function LabelReader() {
+  const { label } = useField()
+  return <span>{label}</span>
+}
+
+describe('useField', () => {
+  it('provides field context when inside a Field', () => {
+    const html = renderToStaticMarkup(
+      <Field name="foo" label="Foo">
+        {() => <LabelReader />}
+      </Field>
+    )
+    expect(html).toContain('<span>Foo</span>')
+  })
+
+  it('throws when used outside a field provider', () => {
+    const render = () => renderToStaticMarkup(<LabelReader />)
+    expect(render).toThrow('useField used outside of field context')
+  })
+})
+
+describe('createField', () => {
+  it('sets input type according to fieldType and radio flag', () => {
+    const htmlDefault = renderToStaticMarkup(<Field name="foo" label="Foo" />)
+    expect(htmlDefault).toContain('type="text"')
+
+    const htmlDate = renderToStaticMarkup(
+      <Field name="foo" label="Foo" fieldType="date" />
+    )
+    expect(htmlDate).toContain('type="date"')
+
+    const htmlRadio = renderToStaticMarkup(
+      <Field
+        name="foo"
+        label="Foo"
+        radio
+        options={[{ name: 'A', value: 'a' }]}
+      />
+    )
+    expect(htmlRadio).toContain('type="radio"')
+  })
+})

--- a/packages/remix-forms/src/mutations.test.ts
+++ b/packages/remix-forms/src/mutations.test.ts
@@ -1,0 +1,143 @@
+import { type ComposableWithSchema, InputError } from 'composable-functions'
+import { describe, expect, it, vi } from 'vitest'
+import * as z from 'zod'
+import {
+  type FormValues,
+  type MutationResult,
+  formAction,
+  performMutation,
+} from './mutations'
+
+function makeRequest(body: URLSearchParams) {
+  return new Request('https://example.com', { method: 'POST', body })
+}
+
+describe('performMutation', () => {
+  it('executes the mutation with parsed values and returns transformed result', async () => {
+    const schema = z.object({ name: z.string(), agree: z.boolean() })
+    const request = makeRequest(
+      new URLSearchParams({ name: 'John', agree: 'on' })
+    )
+
+    const mutation = Object.assign(
+      vi.fn(async (values: { name: string; agree: boolean }) => ({
+        success: true,
+        data: values.name.toUpperCase(),
+      })),
+      { kind: 'composable' }
+    ) as unknown as ComposableWithSchema<string>
+    const transformValues = vi.fn(
+      (values: FormValues<z.infer<typeof schema>>) => values
+    )
+    const transformResult = vi.fn(
+      (r: MutationResult<typeof schema, string>) => r
+    )
+
+    const result = (await performMutation({
+      request,
+      schema,
+      mutation,
+      transformValues,
+      transformResult,
+    })) as MutationResult<typeof schema, string>
+
+    expect(mutation).toHaveBeenCalledWith(
+      { name: 'John', agree: true },
+      undefined
+    )
+    expect(transformValues).toHaveBeenCalled()
+    expect(transformResult).toHaveBeenCalledWith({
+      success: true,
+      data: 'JOHN',
+    })
+    expect(result).toEqual({ success: true, data: 'JOHN' })
+  })
+
+  it('returns values and structured errors on failure', async () => {
+    const schema = z.object({ name: z.string(), agree: z.boolean() })
+    const request = makeRequest(new URLSearchParams({ name: '', agree: '' }))
+
+    const errors = [
+      new InputError('Required', ['name']),
+      new InputError('Too short', ['name']),
+      new InputError('Required', ['agree']),
+      new Error('nope'),
+    ]
+    const mutation = Object.assign(
+      vi.fn(async () => ({ success: false, errors })),
+      { kind: 'composable' }
+    ) as unknown as ComposableWithSchema<unknown>
+
+    const result = (await performMutation({
+      request,
+      schema,
+      mutation,
+    })) as MutationResult<typeof schema, unknown>
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const errors = result.errors as Record<string, string[]>
+      expect(errors.name).toEqual(['Required', 'Too short'])
+      expect(errors.agree).toEqual(['Required'])
+      expect(errors._global).toEqual(['nope'])
+      expect(result.values).toEqual({ name: '', agree: false })
+    }
+  })
+})
+
+describe('formAction', () => {
+  it('redirects when successPath is provided', async () => {
+    const schema = z.object({ name: z.string() })
+    const request = makeRequest(new URLSearchParams({ name: 'Jane' }))
+    const mutation = Object.assign(
+      vi.fn(async () => ({ success: true, data: 'ok' })),
+      { kind: 'composable' }
+    ) as unknown as ComposableWithSchema<string>
+
+    let response: Response | undefined
+    try {
+      await formAction({ request, schema, mutation, successPath: '/done' })
+    } catch (e) {
+      response = e as Response
+    }
+
+    expect(response).toBeInstanceOf(Response)
+    expect(response?.headers.get('Location')).toBe('/done')
+    expect(response?.status).toBe(302)
+  })
+
+  it('wraps the mutation result in DataWithResponseInit', async () => {
+    const schema = z.object({ name: z.string() })
+    const request = makeRequest(new URLSearchParams({ name: 'Jane' }))
+    const mutation = Object.assign(
+      vi.fn(async () => ({ success: true, data: 'ok' })),
+      { kind: 'composable' }
+    ) as unknown as ComposableWithSchema<string>
+
+    const result = await formAction({ request, schema, mutation })
+
+    expect(result).toEqual({
+      type: 'DataWithResponseInit',
+      data: { success: true, data: 'ok' },
+      init: null,
+    })
+  })
+
+  it('uses status 422 for failure results', async () => {
+    const schema = z.object({ name: z.string() })
+    const request = makeRequest(new URLSearchParams({ name: '' }))
+    const mutation = Object.assign(
+      vi.fn(async () => ({
+        success: false,
+        errors: [new InputError('Required', ['name'])],
+      })),
+      { kind: 'composable' }
+    ) as unknown as ComposableWithSchema<unknown>
+
+    const result = await formAction({ request, schema, mutation })
+
+    expect(result.init?.status).toBe(422)
+    const data = result.data as unknown as { success: boolean }
+    expect(data.success).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- add tests for createField and useField
- add tests for performMutation and formAction

## Testing
- `npm run lint`
- `npm run tsc`
- `npm run test` *(fails: With JS enabled we see a refinement validation error)*