### PR TITLE
Add unit tests for SchemaForm and utilities

### DIFF
--- a/packages/remix-forms/src/children-traversal.test.tsx
+++ b/packages/remix-forms/src/children-traversal.test.tsx
@@ -29,6 +29,25 @@ describe('mapChildren', () => {
     const innerP = innerDiv.props.children[0]
     expect(innerP.props['data-mapped']).toBe(true)
   })
+
+  it('removes elements when mapper returns null', () => {
+    const tree = (
+      <div>
+        <span>A</span>
+        <span>B</span>
+      </div>
+    )
+
+    const mapped = mapChildren(tree, (child) =>
+      child.props.children === 'A' ? null : child
+    ) as React.ReactElement[]
+
+    const root = mapped[0]
+    expect(root.props.children.length).toBe(1)
+    const child = root.props.children[0]
+    expect(Array.isArray(child.props.children)).toBe(true)
+    expect(child.props.children[0]).toBe('B')
+  })
 })
 
 describe('reduceElements', () => {
@@ -41,6 +60,22 @@ describe('reduceElements', () => {
     )
     const count = reduceElements(tree, 0, (acc) => acc + 1)
     expect(count).toBe(3)
+  })
+
+  it('handles fragments when reducing elements', () => {
+    const tree = (
+      <div>
+        <>
+          <span>A</span>
+          <span>B</span>
+        </>
+      </div>
+    )
+
+    const text = reduceElements(tree, '', (acc, el) =>
+      el.type === 'span' ? acc + el.props.children : acc
+    )
+    expect(text).toBe('AB')
   })
 })
 

--- a/packages/remix-forms/src/create-field.test.tsx
+++ b/packages/remix-forms/src/create-field.test.tsx
@@ -55,4 +55,16 @@ describe('createField', () => {
     )
     expect(htmlRadio).toContain('type="radio"')
   })
+
+  it('supports boolean and number field types', () => {
+    const htmlBool = renderToStaticMarkup(
+      <Field name="foo" label="Foo" fieldType="boolean" />
+    )
+    expect(htmlBool).toContain('type="checkbox"')
+
+    const htmlNumber = renderToStaticMarkup(
+      <Field name="foo" label="Foo" fieldType="number" />
+    )
+    expect(htmlNumber).toContain('type="text"')
+  })
 })

--- a/packages/remix-forms/src/schema-form.test.tsx
+++ b/packages/remix-forms/src/schema-form.test.tsx
@@ -1,0 +1,40 @@
+import type * as React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+import * as z from 'zod'
+import { SchemaForm } from './schema-form'
+
+vi.mock('react-router', () => ({
+  Form: (props: React.FormHTMLAttributes<HTMLFormElement>) => (
+    <form {...props} />
+  ),
+  useActionData: () => undefined,
+  useNavigation: () => ({ state: 'idle' }),
+  useSubmit: () => () => {},
+}))
+
+describe('SchemaForm', () => {
+  it('renders provided values as form defaults', () => {
+    const schema = z.object({
+      agree: z.boolean(),
+      amount: z.number(),
+      day: z.date(),
+    })
+
+    const html = renderToStaticMarkup(
+      <SchemaForm
+        schema={schema}
+        values={{
+          agree: true,
+          amount: 5,
+          day: new Date('2024-05-06'),
+        }}
+      />
+    )
+
+    expect(html).toContain('type="checkbox"')
+    expect(html).toContain('checked')
+    expect(html).toContain('value="5"')
+    expect(html).toContain('value="2024-05-06"')
+  })
+})


### PR DESCRIPTION
## Summary
- add SchemaForm tests verifying default value rendering
- test more createField input types
- extend children traversal tests with edge cases

## Testing
- `npm run lint`
- `npm run tsc`
- `npm run playwright:ci:install`
- `npm run test`