### PR TITLE
Add missing e2e tests

### DIFF
--- a/apps/web/app/routes/examples/array-of-objects.spec.ts
+++ b/apps/web/app/routes/examples/array-of-objects.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from 'tests/setup/tests'
+
+const route = '/examples/schemas/array-of-objects'
+
+test('With JS enabled', async ({ example }) => {
+  const { button, page } = example
+  const title = example.field('title')
+  const nameInput = page.locator('input[placeholder="Name"]')
+  const emailInput = page.locator('input[placeholder="E-mail"]')
+  const addButton = page.locator('button:has-text("+")')
+
+  await page.goto(route)
+
+  await example.expectField(title)
+  await expect(nameInput).toBeVisible()
+  await expect(emailInput).toBeVisible()
+  await expect(button).toBeEnabled()
+
+  await title.input.fill('Contacts')
+  await nameInput.fill('John')
+  await emailInput.fill('john@doe.com')
+  await addButton.click()
+
+  await nameInput.fill('Jane')
+  await emailInput.fill('jane@doe.com')
+  await addButton.click()
+
+  await page.locator('span:has-text("John (john@doe.com)") button').click()
+
+  await button.click()
+
+  await example.expectData({
+    title: 'Contacts',
+    contacts: [{ name: 'Jane', email: 'jane@doe.com' }],
+  })
+})

--- a/apps/web/app/routes/examples/array-of-strings.spec.ts
+++ b/apps/web/app/routes/examples/array-of-strings.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from 'tests/setup/tests'
+
+const route = '/examples/schemas/array-of-strings'
+
+test('With JS enabled', async ({ example }) => {
+  const { button, page } = example
+  const title = example.field('title')
+  const tagInput = page.locator(
+    'input[placeholder="Add a tag and press Enter..."]'
+  )
+
+  await page.goto(route)
+
+  await example.expectField(title)
+  await expect(tagInput).toBeVisible()
+  await expect(button).toBeEnabled()
+
+  await title.input.fill('My post')
+  await tagInput.fill('foo')
+  await tagInput.press('Enter')
+  await tagInput.fill('bar')
+  await tagInput.press('Enter')
+  await page.locator('span:has-text("foo") button').click()
+
+  await button.click()
+
+  await example.expectData({ title: 'My post', tags: ['bar'] })
+})

--- a/apps/web/app/routes/examples/dynamic-form.spec.ts
+++ b/apps/web/app/routes/examples/dynamic-form.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from 'tests/setup/tests'
+
+const route = '/examples/forms/dynamic-form'
+
+test('With JS enabled', async ({ example }) => {
+  const { button, page } = example
+  const firstName = example.field('firstName')
+  const email = example.field('email')
+  const age = example.field('age')
+
+  await page.goto(route)
+
+  await example.expectField(firstName)
+  await example.expectField(email)
+  await example.expectField(age)
+  await expect(button).toBeEnabled()
+
+  await firstName.input.fill('John')
+  await email.input.fill('john@doe.com')
+  await age.input.fill('42')
+
+  await button.click()
+
+  await example.expectData({
+    firstName: 'John',
+    email: 'john@doe.com',
+    age: 42,
+  })
+})

--- a/apps/web/app/routes/examples/multiple-forms.spec.ts
+++ b/apps/web/app/routes/examples/multiple-forms.spec.ts
@@ -1,0 +1,27 @@
+import { test } from 'tests/setup/tests'
+
+const route = '/examples/forms/multiple-forms'
+
+test('With JS enabled', async ({ example }) => {
+  const { page } = example
+  const loginEmail = page.locator(
+    'form:has(button:has-text("Login")) [name="email"]'
+  )
+  const loginPassword = page.locator(
+    'form:has(button:has-text("Login")) [name="password"]'
+  )
+  const loginButton = page.locator('form button:has-text("Login")')
+
+  await page.goto(route)
+
+  await loginEmail.fill('john@doe.com')
+  await loginPassword.fill('password123')
+  await loginButton.click()
+  await page.waitForLoadState('networkidle')
+
+  await example.expectData({
+    _action: '/login',
+    email: 'john@doe.com',
+    password: 'password123',
+  })
+})

--- a/apps/web/app/routes/examples/use-form-state.spec.ts
+++ b/apps/web/app/routes/examples/use-form-state.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from 'tests/setup/tests'
+
+const route = '/examples/forms/use-form-state'
+
+test('With JS enabled', async ({ example }) => {
+  const { button, page } = example
+  const age = example.field('age')
+
+  await page.goto(route)
+
+  await example.expectField(age)
+  await expect(button).toBeDisabled()
+
+  await age.input.fill('5')
+  await expect(button).toBeEnabled()
+
+  await button.click()
+
+  await example.expectData({ age: 5 })
+})


### PR DESCRIPTION
## Summary
- add Playwright specs for remaining examples
- cover array-of-objects, array-of-strings, dynamic forms, multiple forms and useFormState

## Testing
- `npx playwright test app/routes/examples/array-of-objects.spec.ts app/routes/examples/array-of-strings.spec.ts app/routes/examples/dynamic-form.spec.ts app/routes/examples/multiple-forms.spec.ts app/routes/examples/use-form-state.spec.ts --reporter=line`
