### PR TITLE
Add simple e2e tests

### DIFF
--- a/apps/web/app/routes/conf/01.spec.ts
+++ b/apps/web/app/routes/conf/01.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test } from 'tests/setup/tests'
+
+const route = '/conf/01'
+
+test('Redirects to success and back', async ({ example }) => {
+  const { page } = example
+
+  await page.goto(route)
+
+  await page.click('form button:has-text("Make reservation")')
+  await expect(page).toHaveURL('/conf/success/01')
+  const back = page.getByRole('link', { name: 'Go back' })
+  await expect(back).toHaveAttribute('href', '/conf/01')
+  await back.click()
+  await expect(page).toHaveURL('/conf/01')
+})

--- a/apps/web/app/routes/get-started.spec.ts
+++ b/apps/web/app/routes/get-started.spec.ts
@@ -1,0 +1,14 @@
+import { expect, test } from 'tests/setup/tests'
+
+const route = '/get-started'
+
+test('Get Started page shows installation info', async ({ example }) => {
+  const { page } = example
+
+  await page.goto(route)
+
+  await expect(page.locator('h1')).toHaveText('Get Started')
+  await expect(
+    page.getByRole('link', { name: 'Check out more examples' })
+  ).toHaveAttribute('href', '/examples')
+})

--- a/apps/web/app/routes/success.spec.ts
+++ b/apps/web/app/routes/success.spec.ts
@@ -1,0 +1,14 @@
+import { expect, test } from 'tests/setup/tests'
+
+const route = '/success'
+
+test('Displays success message and link', async ({ example }) => {
+  const { page } = example
+
+  await page.goto(route)
+
+  await expect(page.locator('h1')).toHaveText('Success! 🎉')
+  await expect(
+    page.getByRole('link', { name: /other examples/ })
+  ).toHaveAttribute('href', '/examples')
+})


### PR DESCRIPTION
## Summary
- add missing Playwright specs for `/get-started` and `/success`
- cover the first config example `/conf/01`

## Testing
- `npm run lint`
- `npm run tsc`
- `npm run test` *(fails: page.goto: Protocol error)*