### PR TITLE
Add field rendering tests

### DIFF
--- a/packages/remix-forms/src/create-field.test.tsx
+++ b/packages/remix-forms/src/create-field.test.tsx
@@ -79,4 +79,28 @@ describe('createField', () => {
     )
     expect(html).toContain('value="2024-01-02"')
   })
+
+  it('renders select options when provided', () => {
+    const html = renderToStaticMarkup(
+      <Field
+        name="foo"
+        label="Foo"
+        options={[
+          { name: 'A', value: 'a' },
+          { name: 'B', value: 'b' },
+        ]}
+      />
+    )
+    expect(html).toContain('<select')
+    expect(html).toContain('<option value="a">A</option>')
+    expect(html).toContain('<option value="b">B</option>')
+  })
+
+  it('applies placeholder and hidden style', () => {
+    const html = renderToStaticMarkup(
+      <Field name="foo" label="Foo" placeholder="Enter" hidden />
+    )
+    expect(html).toContain('placeholder="Enter"')
+    expect(html).toContain('style="display:none"')
+  })
 })


### PR DESCRIPTION
## Summary
- test select and hidden field behavior in createField

## Testing
- `npm run lint`
- `npm run tsc`
- `npm run test` *(fails: routes/examples/enums.spec.ts etc.)*