### PR TITLE
Add tests for createField

### DIFF
--- a/packages/remix-forms/src/create-field.test.tsx
+++ b/packages/remix-forms/src/create-field.test.tsx
@@ -1,10 +1,11 @@
+import * as React from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import type { UseFormRegister } from 'react-hook-form'
 import { describe, expect, it, vi } from 'vitest'
 import { createField, useField } from './create-field'
 
-const register = vi.fn(() => ({
-  name: 'foo',
+const register = vi.fn((name: string) => ({
+  name,
   onChange: () => Promise.resolve(),
   onBlur: () => Promise.resolve(),
   ref: () => {},
@@ -13,6 +14,14 @@ import * as z from 'zod'
 
 const schema = z.object({ foo: z.string() })
 const Field = createField<typeof schema>({ register })
+const choiceSchema = z.object({ choice: z.string() })
+const ChoiceField = createField<typeof choiceSchema>({
+  register,
+  radioComponent: React.forwardRef<
+    HTMLInputElement,
+    React.ComponentPropsWithoutRef<'input'>
+  >((props, ref) => <input ref={ref} {...props} />),
+})
 
 function LabelReader() {
   const { label } = useField()
@@ -102,5 +111,51 @@ describe('createField', () => {
     )
     expect(html).toContain('placeholder="Enter"')
     expect(html).toContain('style="display:none"')
+  })
+
+  it('sets aria attributes and renders errors', () => {
+    const html = renderToStaticMarkup(
+      <Field name="foo" label="Foo" required errors={['Required']} />
+    )
+
+    expect(html).toContain('aria-invalid="true"')
+    expect(html).toContain('aria-required="true"')
+    expect(html).toContain('id="errors-for-foo"')
+    expect(html).toContain('Required')
+  })
+
+  it('links radio labels to generated ids when using children', () => {
+    const html = renderToStaticMarkup(
+      <ChoiceField
+        name="choice"
+        label="Choice"
+        radio
+        options={[
+          { name: 'A', value: 'a' },
+          { name: 'B', value: 'b' },
+        ]}
+      >
+        {({ Label, RadioGroup, RadioWrapper, Radio }) => (
+          <>
+            <Label>Pick one</Label>
+            <RadioGroup>
+              <RadioWrapper>
+                <Radio value="a" type="radio" />
+                <Label>A</Label>
+              </RadioWrapper>
+              <RadioWrapper>
+                <Radio value="b" type="radio" />
+                <Label>B</Label>
+              </RadioWrapper>
+            </RadioGroup>
+          </>
+        )}
+      </ChoiceField>
+    )
+
+    expect(html).toContain('id="choice-a"')
+    expect(html).toContain('for="choice-a"')
+    expect(html).toContain('id="choice-b"')
+    expect(html).toContain('for="choice-b"')
   })
 })


### PR DESCRIPTION
## Summary
- add missing unit tests for createField
- ensure radio labels use generated ids
- cover aria attributes and error rendering

## Testing
- `npx vitest run --dir packages/remix-forms/src`
- `npm run lint`
- `npm run tsc`
- `npm run test` *(fails: examples tests fail)*