### PR TITLE
Add missing SchemaForm fetcher Form test

### DIFF
--- a/packages/remix-forms/src/schema-form.test.tsx
+++ b/packages/remix-forms/src/schema-form.test.tsx
@@ -390,3 +390,20 @@ it('uses fieldErrorsComponent and errorComponent when provided', () => {
   expect(html).toContain('data-field-errors="true"')
   expect(html).toContain('<span data-error="true">Oops</span>')
 })
+
+it('uses fetcher.Form when fetcher is supplied', () => {
+  const schema = z.object({ name: z.string() })
+  const fetcher = {
+    submit: vi.fn(),
+    state: 'idle',
+    Form: (props: React.FormHTMLAttributes<HTMLFormElement>) => (
+      <form data-fetcher {...props} />
+    ),
+  }
+
+  const html = renderToStaticMarkup(
+    <SchemaForm schema={schema} fetcher={fetcher as never} />
+  )
+
+  expect(html).toContain('data-fetcher="true"')
+})


### PR DESCRIPTION
## Summary
- add a test ensuring `SchemaForm` uses `fetcher.Form` when provided

## Testing
- `npm run lint-fix`
- `npm run lint`
- `npm run tsc`
- `npm run playwright:ci:install`
- `npm run test` *(fails: Playwright routes/examples/labels-options-etc.spec.ts timed out)*