### PR TITLE
Improve public API TSDocs

### DIFF
--- a/packages/remix-forms/src/create-field.tsx
+++ b/packages/remix-forms/src/create-field.tsx
@@ -149,10 +149,14 @@ const FieldContext = React.createContext<
 >(undefined)
 
 /**
- * Access information about the currently rendered field inside custom
- * components.
+ * Access information about the field currently being rendered.
  *
- * @returns Data describing the field being rendered
+ * This hook is meant to be used from inside custom components passed to
+ * {@link SchemaForm} or {@link RenderField}. It exposes metadata such as the
+ * computed label, validation errors and the coerced value so that custom
+ * inputs can easily hook into the form.
+ *
+ * @returns Field data including `label`, `errors` and `value`.
  *
  * @example
  * ```tsx

--- a/packages/remix-forms/src/mutations.ts
+++ b/packages/remix-forms/src/mutations.ts
@@ -86,6 +86,10 @@ type FormErrors<SchemaType> = Partial<
  * Result of a mutation executed by {@link performMutation} or
  * {@link formAction}.
  *
+ * The object indicates whether the mutation succeeded and either contains the
+ * returned data or a map of validation errors keyed by field name. This type is
+ * useful for typing loader and action responses.
+ *
  * @example
  * ```ts
  * if (result.success) console.log(result.data)
@@ -126,7 +130,9 @@ type PerformMutationProps<Schema extends FormSchema, D> = {
  *
  * @example
  * ```ts
- * formAction({ request, schema, mutation, successPath: '/done' })
+ * // inside a route action
+ * export const action = async ({ request }) =>
+ *   formAction({ request, schema, mutation, successPath: '/done' })
  * ```
  *
  * @example
@@ -175,6 +181,9 @@ async function getFormValues<Schema extends FormSchema>(
  * ```ts
  * performMutation({ request, schema, mutation, context: { user } })
  * ```
+ *
+ * This helper is usually used from {@link formAction} but can also be called
+ * directly when you need custom handling of the mutation result.
  */
 async function performMutation<Schema extends FormSchema, D>({
   request,
@@ -228,6 +237,10 @@ async function performMutation<Schema extends FormSchema, D>({
  * ```ts
  * formAction({ request, schema, mutation, successPath: '/thanks' })
  * ```
+ *
+ * Use this function as your route's action to parse the form values, execute
+ * the mutation and respond with either a redirect or an object containing the
+ * errors and submitted values.
  */
 async function formAction<Schema extends FormSchema, D>({
   successPath,

--- a/packages/remix-forms/src/prelude.ts
+++ b/packages/remix-forms/src/prelude.ts
@@ -5,6 +5,8 @@ import type { z } from 'zod'
  *
  * This type covers plain objects as well as Zod effects so you can pass
  * schemas created with refinements or preprocessors.
+ * It is mainly used as a generic constraint for {@link SchemaForm} and the
+ * mutation helpers.
  *
  * @example
  * ```ts

--- a/packages/remix-forms/src/schema-form.tsx
+++ b/packages/remix-forms/src/schema-form.tsx
@@ -61,8 +61,10 @@ type Field<SchemaType> = {
 /**
  * Props passed to a custom field rendering component.
  *
- * The `Field` component is provided so callers can easily render individual
- * fields using the same mappings as `SchemaForm`.
+ * When using the {@link SchemaForm.renderField | renderField} prop you
+ * receive these props for each field in the schema. They include the built
+ * in `Field` component plus the computed metadata for that particular form
+ * field.
  *
  * @example
  * ```tsx
@@ -80,6 +82,9 @@ type RenderFieldProps<Schema extends SomeZodObject> = Field<z.infer<Schema>> & {
 
 /**
  * Function signature used for rendering form fields.
+ *
+ * The function is called once for every key in the provided schema and
+ * should return the JSX that renders that field.
  *
  * @example
  * ```tsx
@@ -114,10 +119,11 @@ type OnNavigation<Schema extends SomeZodObject> = (
 ) => void
 
 /**
- * Props for the {@link SchemaForm} component.
+ * Props accepted by {@link SchemaForm}.
  *
- * These options control how the form is rendered and how values and errors
- * are populated.
+ * These options control how the form is rendered and where values and errors
+ * come from. In the simplest case you only need to pass a {@link FormSchema}
+ * but every aspect of the UI can be customised via these props.
  *
  * @example
  * ```tsx
@@ -193,10 +199,13 @@ function coerceToForm(value: unknown, shape: ShapeInfo) {
 }
 
 /**
- * Render a form based on a Zod schema.
+ * Render a form based on a {@link FormSchema}.
  *
- * This component automatically wires up inputs with React Hook Form and
- * handles client-side validation.
+ * This component is the easiest way to create a form in Remix. It
+ * automatically wires up inputs with React Hook Form, handles client side
+ * validation and integrates with React Router navigation state.
+ * Provide a schema and the form will generate fields and labels
+ * automatically.
  *
  * @param props.component - Form component used for rendering
  * @param props.fetcher - Fetcher object returned by `useFetcher()`
@@ -240,12 +249,17 @@ function coerceToForm(value: unknown, shape: ShapeInfo) {
  *
  * @example
  * ```tsx
- * <SchemaForm schema={schema} />
+ * const schema = z.object({ name: z.string() })
+ *
+ * export default function Route() {
+ *   return <SchemaForm schema={schema} />
+ * }
  * ```
  *
  * @example
  * ```tsx
- * <SchemaForm schema={schema} fetcher={useFetcher()} />
+ * const fetcher = useFetcher()
+ * <SchemaForm schema={schema} fetcher={fetcher} />
  * ```
  */
 function SchemaForm<Schema extends FormSchema>({


### PR DESCRIPTION
## Summary
- expand documentation for `useField`
- clarify `SchemaFormProps` usage
- add more details and examples to `SchemaForm`
- document renderField props and function better
- clarify mutation-related types and helpers
- mention how `FormSchema` is used

## Testing
- `npm run lint-fix`
- `npm run lint`
- `npm run tsc`
- `npm run test`