### PR TITLE
Add empty option label example

### DIFF
--- a/apps/web/app/routes.ts
+++ b/apps/web/app/routes.ts
@@ -46,6 +46,7 @@ export const exampleRouteGroups = {
     'Multiple forms',
     'Imperative submit',
     'Dynamic form',
+    'Empty option label',
   ],
   renderField: [
     'Required indicator',

--- a/apps/web/app/routes/examples/empty-option-label.spec.ts
+++ b/apps/web/app/routes/examples/empty-option-label.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test, testWithoutJS } from 'tests/setup/tests'
+
+const route = '/examples/forms/empty-option-label'
+
+test('With JS enabled', async ({ example }) => {
+  const { button, page } = example
+  const choice = example.field('choice')
+
+  await page.goto(route)
+
+  await example.expectSelect(choice, { required: false, value: '' })
+  const options = choice.input.locator('option')
+  await expect(options.first()).toHaveText('Select one')
+  await expect(options.last()).toHaveText('Dev')
+
+  await choice.input.selectOption('designer')
+  await button.click()
+  await expect(button).toBeDisabled()
+  await example.expectData({ choice: 'designer' })
+})
+
+testWithoutJS('With JS disabled', async ({ example }) => {
+  const { button, page } = example
+  const choice = example.field('choice')
+
+  await page.goto(route)
+
+  await example.expectSelect(choice, { required: false, value: '' })
+  const options = choice.input.locator('option')
+  await expect(options.first()).toHaveText('Select one')
+  await expect(options.last()).toHaveText('Dev')
+
+  await choice.input.selectOption('designer')
+  await button.click()
+  await page.reload()
+  await example.expectData({ choice: 'designer' })
+})

--- a/apps/web/app/routes/examples/empty-option-label.tsx
+++ b/apps/web/app/routes/examples/empty-option-label.tsx
@@ -1,0 +1,42 @@
+import { applySchema } from 'composable-functions'
+import hljs from 'highlight.js/lib/common'
+import { formAction } from 'remix-forms'
+import { z } from 'zod'
+import { metaTags } from '~/helpers'
+import Example from '~/ui/example'
+import { SchemaForm } from '~/ui/schema-form'
+import type { Route } from './+types/empty-option-label'
+
+const title = 'Empty option label'
+const description = 'Customize the label shown for optional select fields.'
+
+export const meta: Route.MetaFunction = () => metaTags({ title, description })
+
+const code = `const schema = z.object({
+  choice: z.enum(['designer', 'dev']).optional(),
+})
+
+export default () => (
+  <SchemaForm schema={schema} emptyOptionLabel="Select one" />
+)`
+
+const schema = z.object({
+  choice: z.enum(['designer', 'dev']).optional(),
+})
+
+export const loader = () => ({
+  code: hljs.highlight(code, { language: 'ts' }).value,
+})
+
+const mutation = applySchema(schema)(async (values) => values)
+
+export const action = async ({ request }: Route.ActionArgs) =>
+  formAction({ request, schema, mutation })
+
+export default function Component() {
+  return (
+    <Example title={title} description={description}>
+      <SchemaForm schema={schema} emptyOptionLabel="Select one" />
+    </Example>
+  )
+}


### PR DESCRIPTION
## Summary
- demonstrate `emptyOptionLabel` in a new example page
- list the page in the examples menu
- test the new page with Playwright

## Testing
- `npm run lint-fix`
- `npm run lint`
- `npm run tsc`
- `npm run test`
