### PR TITLE
Add missing parseDate coverage

### DIFF
--- a/packages/remix-forms/src/prelude.test.ts
+++ b/packages/remix-forms/src/prelude.test.ts
@@ -39,6 +39,10 @@ describe('parseDate', () => {
   it('passes through date strings unchanged', () => {
     expect(parseDate('2024-05-06T07:08:09Z')).toBe('2024-05-06')
   })
+
+  it('keeps YYYY-MM-DD strings as is', () => {
+    expect(parseDate('2024-05-06')).toBe('2024-05-06')
+  })
 })
 
 describe('browser', () => {


### PR DESCRIPTION
## Summary
- expand parseDate tests

## Testing
- `npm run lint-fix`
- `npm run lint`
- `npm run tsc`
- `npm run test` *(fails: Test run requires heavy Playwright setup)*