### PR TITLE
Add a few extra tests

### DIFF
--- a/packages/remix-forms/src/coercions.test.ts
+++ b/packages/remix-forms/src/coercions.test.ts
@@ -103,4 +103,8 @@ describe('coerceValue', () => {
       coerceValue(new File([], 'some-empty-file.txt'), z.enum(['test']))
     ).toMatch(/[object (File|Blob)]/)
   })
+
+  it('returns enum value when provided', () => {
+    expect(coerceValue('one', z.enum(['one', 'two']))).toBe('one')
+  })
 })

--- a/packages/remix-forms/src/infer-label.test.ts
+++ b/packages/remix-forms/src/infer-label.test.ts
@@ -24,4 +24,8 @@ describe('inferLabel', () => {
       'Some Mixed String With Spaces Underscores And Hyphens',
     ])
   })
+
+  it('keeps numbers as part of the name', () => {
+    expect(inferLabel('field1Name')).toBe('Field1 Name')
+  })
 })


### PR DESCRIPTION
## Summary
- test coercions enum value pass-through
- cover numeric names in inferLabel

## Testing
- `npm test` (fails: timed out running Playwright tests)
- `cd packages/remix-forms && npm test`