### PR TITLE
Add hidden field error unit test

### DIFF
--- a/packages/remix-forms/src/hidden-errors.test.tsx
+++ b/packages/remix-forms/src/hidden-errors.test.tsx
@@ -1,0 +1,33 @@
+import type * as React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+import * as z from 'zod'
+import { SchemaForm } from './schema-form'
+
+vi.mock('react-router', () => {
+  return {
+    Form: (props: React.FormHTMLAttributes<HTMLFormElement>) => (
+      <form {...props} />
+    ),
+    useActionData: vi.fn(() => undefined),
+    useNavigation: vi.fn(() => ({ state: 'idle' })),
+    useSubmit: () => () => {},
+  }
+})
+
+describe('SchemaForm hidden field errors', () => {
+  it('promotes hidden field errors to global errors', () => {
+    const schema = z.object({ visible: z.string(), secret: z.string() })
+    const html = renderToStaticMarkup(
+      <SchemaForm
+        schema={schema}
+        hiddenFields={['secret']}
+        labels={{ secret: 'Secret' }}
+        errors={{ secret: ['Missing'] }}
+      />
+    )
+
+    expect(html).toContain('role="alert"')
+    expect(html).toContain('Secret: Missing')
+  })
+})


### PR DESCRIPTION
## Summary
- add coverage for hidden field error behavior

## Testing
- `npm --workspace packages/remix-forms run test`
- `npm run test` *(fails: chromium E2E tests require browser binaries)*