### PR TITLE
Add coverage for autoFocus and enum labels

### DIFF
--- a/packages/remix-forms/src/create-field.test.tsx
+++ b/packages/remix-forms/src/create-field.test.tsx
@@ -171,6 +171,13 @@ describe('createField', () => {
     expect(html).toContain('style="display:none"')
   })
 
+  it('sets the autoFocus attribute when requested', () => {
+    const html = renderToStaticMarkup(
+      <Field name="foo" label="Foo" autoFocus />
+    )
+    expect(html).toMatch(/autofocus/i)
+  })
+
   it('sets aria attributes and renders errors', () => {
     const html = renderToStaticMarkup(
       <Field name="foo" label="Foo" required errors={['Required']} />

--- a/packages/remix-forms/src/schema-form.test.tsx
+++ b/packages/remix-forms/src/schema-form.test.tsx
@@ -135,6 +135,18 @@ describe('SchemaForm', () => {
     expect(html).toContain('<option value="b">B</option>')
   })
 
+  it('infers option labels from enum values', () => {
+    const schema = z.object({
+      choice: z.enum(['foo', 'barBaz']),
+    })
+
+    const html = renderToStaticMarkup(<SchemaForm schema={schema} />)
+
+    expect(html).toContain('<select')
+    expect(html).toContain('<option value="foo">Foo</option>')
+    expect(html).toContain('<option value="barBaz">Bar Baz</option>')
+  })
+
   it('renders beforeChildren content before the fields', () => {
     const schema = z.object({
       name: z.string(),


### PR DESCRIPTION
## Summary
- add test for autoFocus attribute in `createField`
- add test for inferring labels from enum values

## Testing
- `npm run lint-fix`
- `npm run lint`
- `npm run tsc`
- `npm run test`