### PR TITLE
Add tests for mutation helpers

### DIFF
--- a/packages/remix-forms/src/internal-mutations.test.ts
+++ b/packages/remix-forms/src/internal-mutations.test.ts
@@ -1,0 +1,56 @@
+import { InputError } from 'composable-functions'
+import { describe, expect, it } from 'vitest'
+import * as z from 'zod'
+import { errorMessagesForSchema, getFormValues } from './mutations'
+
+function makeRequest(body: URLSearchParams) {
+  return new Request('https://example.com', { method: 'POST', body })
+}
+
+describe('errorMessagesForSchema', () => {
+  it('aggregates messages by path', () => {
+    const schema = z.object({
+      user: z.object({ name: z.string(), age: z.number() }),
+    })
+    const errors = [
+      new InputError('Required', ['user', 'name']),
+      new InputError('Too short', ['user', 'name']),
+      new InputError('Invalid', ['user', 'age']),
+      new Error('global'),
+    ]
+
+    const result = errorMessagesForSchema(errors, schema)
+
+    expect(result).toEqual({
+      user: { name: ['Required', 'Too short'], age: ['Invalid'] },
+    })
+  })
+})
+
+describe('getFormValues', () => {
+  it('parses and coerces values from the request', async () => {
+    const schema = z.object({
+      name: z.string(),
+      agree: z.boolean(),
+      amount: z.number().optional(),
+      day: z.date().nullable(),
+    })
+    const request = makeRequest(
+      new URLSearchParams({
+        name: 'Jane',
+        agree: 'on',
+        amount: '5',
+        day: '2024-05-06',
+      })
+    )
+
+    const values = await getFormValues(request, schema)
+
+    expect(values).toEqual({
+      name: 'Jane',
+      agree: true,
+      amount: 5,
+      day: new Date(2024, 4, 6),
+    })
+  })
+})

--- a/packages/remix-forms/src/mutations.ts
+++ b/packages/remix-forms/src/mutations.ts
@@ -16,6 +16,19 @@ type NestedErrors<SchemaType> = {
   [Property in keyof SchemaType]: string[] | NestedErrors<SchemaType[Property]>
 }
 
+/**
+ * Build a nested error object from a list of {@link InputError|InputErrors}.
+ *
+ * @param errors - Errors returned by the mutation
+ * @param schema - Schema describing the expected values
+ * @returns Nested map of error messages keyed by path
+ *
+ * @example
+ * ```ts
+ * const errors = [new InputError('Required', ['name'])]
+ * errorMessagesForSchema(errors, schema)
+ * ```
+ */
 function errorMessagesForSchema<T extends z.ZodTypeAny>(
   errors: Error[],
   _schema: T
@@ -144,6 +157,18 @@ type FormActionProps<Schema extends FormSchema, D> = {
   successPath?: ((data: D) => string | Promise<string>) | string
 } & PerformMutationProps<Schema, D>
 
+/**
+ * Read form data from a request and coerce values according to the schema.
+ *
+ * @param request - HTTP request containing form data
+ * @param schema - Zod schema describing the form fields
+ * @returns Parsed and coerced form values
+ *
+ * @example
+ * ```ts
+ * const values = await getFormValues(request, schema)
+ * ```
+ */
 async function getFormValues<Schema extends FormSchema>(
   request: Request,
   schema: Schema
@@ -273,4 +298,4 @@ export type {
   FormActionProps,
 }
 
-export { performMutation, formAction }
+export { performMutation, formAction, errorMessagesForSchema, getFormValues }


### PR DESCRIPTION
## Summary
- expose helper functions from mutations
- test error message nesting
- test form value coercion

## Testing
- `npm run lint-fix`
- `npm run lint`
- `npm run tsc`
- `npm run test` *(fails: 2 playwright tests)*