### PR TITLE
Fix 349 accented letters

### DIFF
--- a/apps/web/app/routes/examples/radio-buttons.spec.ts
+++ b/apps/web/app/routes/examples/radio-buttons.spec.ts
@@ -17,6 +17,10 @@ test('With JS enabled', async ({ example }) => {
     { name: 'HR', value: 'HR' },
     { name: 'IT', value: 'IT' },
   ])
+  await example.expectRadioToHaveOptions('department', [
+    { name: 'Ângelo', value: 'Ângelo' },
+    { name: 'João', value: 'João' },
+  ])
   await expect(button).toBeEnabled()
 
   // Client-side validation

--- a/apps/web/app/routes/examples/radio-buttons.tsx
+++ b/apps/web/app/routes/examples/radio-buttons.tsx
@@ -16,15 +16,17 @@ export const meta: Route.MetaFunction = () => metaTags({ title, description })
 const code = `const schema = z.object({
   role: z.enum(['Designer', 'Dev']),
   department: z.enum(['HR', 'IT']).default('IT'),
+  assignee: z.enum(["Ângelo", "João"]).default("João"),
 })
 
 export default () => (
-  <SchemaForm schema={schema} radio={['role', 'department']} />
+  <SchemaForm schema={schema} radio={['role', 'department', 'assignee']} />
 )`
 
 const schema = z.object({
   role: z.enum(['Designer', 'Dev']),
   department: z.enum(['HR', 'IT']).default('IT'),
+  assignee: z.enum(["Ângelo", "João"]).default("João"),
 })
 
 export const loader = () => ({
@@ -39,7 +41,7 @@ export const action = async ({ request }: Route.ActionArgs) =>
 export default function Component() {
   return (
     <Example title={title} description={description}>
-      <SchemaForm schema={schema} radio={['role', 'department']} />
+      <SchemaForm schema={schema} radio={['role', 'department', 'assignee']} />
     </Example>
   )
 }

--- a/packages/remix-forms/src/infer-label.ts
+++ b/packages/remix-forms/src/infer-label.ts
@@ -1,7 +1,5 @@
 function startCase(str: string): string {
-  const matches = str.match(
-    /[A-Z]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+[0-9]*|[A-Z]|[0-9]+/g
-  ) ?? ['']
+  const matches = str.match(/\p{L}+(?:'\p{L}+)?|\d+/gu) ?? ['']
   return matches.map((x) => x.charAt(0).toUpperCase() + x.slice(1)).join(' ')
 }
 


### PR DESCRIPTION
Fixes #349 

This PR changes the `infer-label` function to take into account accented letters.

I'm not the best with RegExp so please criticize and change freely.

`\p{L}`: Matches any kind of letter from any language, including accented letters (This is part of Unicode property escapes).
`(?:'\p{L}+)?`: This non-capturing group matches apostrophes followed by letters (useful for handling cases like "l'école").
`\d+`: Matches sequences of digits (This allows numbers to be treated as separate words).
`u`: The Unicode flag (ensures that the regular expression handles Unicode characters properly).
`g`: The global flag

This PR also adds an example to the Radio Buttons and a test — not really necessary, but surely adds safety and 💅 — it makes sure things look the way they should.