### PR TITLE
Fix accented labels in selects

### DIFF
--- a/apps/web/app/routes.ts
+++ b/apps/web/app/routes.ts
@@ -62,6 +62,7 @@ const testRoutes = [
   'field-with-radio-children',
   'field-with-ref',
   'hidden-field-with-errors',
+  'accented-options',
 ]
 
 export const exampleRoutesToPrerender = Object.entries(exampleRouteGroups)

--- a/apps/web/app/routes/tests/accented-options.spec.ts
+++ b/apps/web/app/routes/tests/accented-options.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from 'tests/setup/tests'
+
+const route = '/test-examples/accented-options'
+
+test('Renders options with accents', async ({ example }) => {
+  const { page } = example
+  const travel = example.field('travel')
+
+  await page.goto(route)
+  await example.expectSelect(travel, { value: 'avião' })
+
+  const options = travel.input.locator('option')
+  await expect(options.nth(0)).toHaveText('Avião')
+  await expect(options.nth(1)).toHaveText('Ônibus')
+})

--- a/apps/web/app/routes/tests/accented-options.tsx
+++ b/apps/web/app/routes/tests/accented-options.tsx
@@ -1,0 +1,35 @@
+import { applySchema } from 'composable-functions'
+import hljs from 'highlight.js/lib/common'
+import { formAction } from 'remix-forms'
+import { z } from 'zod'
+import { metaTags } from '~/helpers'
+import Example from '~/ui/example'
+import { SchemaForm } from '~/ui/schema-form'
+import type { Route } from './+types/accented-options'
+
+const title = 'Select with accented options'
+const description =
+  'In this example, labels inferred from z.enum values contain accents.'
+
+export const meta: Route.MetaFunction = () => metaTags({ title, description })
+
+const schema = z.object({
+  travel: z.enum(['avião', 'ônibus']).default('avião'),
+})
+
+export const loader = () => ({
+  code: hljs.highlight('', { language: 'ts' }).value,
+})
+
+const mutation = applySchema(schema)(async (values) => values)
+
+export const action = async ({ request }: Route.ActionArgs) =>
+  formAction({ request, schema, mutation })
+
+export default function Component() {
+  return (
+    <Example title={title} description={description}>
+      <SchemaForm schema={schema} />
+    </Example>
+  )
+}

--- a/packages/remix-forms/src/infer-label.test.ts
+++ b/packages/remix-forms/src/infer-label.test.ts
@@ -28,4 +28,9 @@ describe('inferLabel', () => {
   it('keeps numbers as part of the name', () => {
     expect(inferLabel('field1Name')).toBe('Field1 Name')
   })
+
+  it('keeps accents when inferring labels', () => {
+    expect(inferLabel('avião')).toBe('Avião')
+    expect(inferLabel('ônibus')).toBe('Ônibus')
+  })
 })

--- a/packages/remix-forms/src/infer-label.test.ts
+++ b/packages/remix-forms/src/infer-label.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { inferLabel } from './infer-label'
+import { inferLabel, startCase } from './infer-label'
 
 describe('inferLabel', () => {
   it('capitalizes the field name', () => {
@@ -32,5 +32,31 @@ describe('inferLabel', () => {
   it('keeps accents when inferring labels', () => {
     expect(inferLabel('avião')).toBe('Avião')
     expect(inferLabel('ônibus')).toBe('Ônibus')
+  })
+})
+
+describe('startCase', () => {
+  it('handles camelCase with acronyms and numbers', () => {
+    expect(startCase('fooBarHTML42')).toBe('Foo Bar HTML 42')
+  })
+
+  it('handles words with apostrophes', () => {
+    expect(startCase("rock'n'roll")).toBe("Rock'n'Roll")
+  })
+
+  it('handles multiple apostrophes in camelCase', () => {
+    expect(startCase("can'tStopWon'tStop")).toBe("Can't Stop Won't Stop")
+  })
+
+  it('handles trailing numbers', () => {
+    expect(startCase('item42')).toBe('Item42')
+  })
+
+  it('splits camel cased acronyms', () => {
+    expect(startCase('XMLHttpRequest')).toBe('XML Http Request')
+  })
+
+  it('handles a leading apostrophe', () => {
+    expect(startCase("'tisTheSeason")).toBe("'Tis The Season")
   })
 })

--- a/packages/remix-forms/src/infer-label.ts
+++ b/packages/remix-forms/src/infer-label.ts
@@ -1,7 +1,8 @@
 function startCase(str: string): string {
   const matches = str.match(
-    /[A-Z]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+[0-9]*|[A-Z]|[0-9]+/g
+    /[\p{Lu}]{2,}(?=[\p{Lu}][\p{Ll}]+[\p{N}]*|\b)|[\p{Lu}]?[\p{Ll}]+[\p{N}]*|[\p{Lu}]|[\p{N}]+/gu
   ) ?? ['']
+
   return matches.map((x) => x.charAt(0).toUpperCase() + x.slice(1)).join(' ')
 }
 

--- a/packages/remix-forms/src/infer-label.ts
+++ b/packages/remix-forms/src/infer-label.ts
@@ -1,13 +1,25 @@
 function startCase(str: string): string {
-  const matches = str.match(
-    /[\p{Lu}]{2,}(?=[\p{Lu}][\p{Ll}]+[\p{N}]*|\b)|[\p{Lu}]?[\p{Ll}]+[\p{N}]*|[\p{Lu}]|[\p{N}]+/gu
+  const words = str.match(
+    /[\p{Lu}]{2,}(?=[\p{Lu}][\p{Ll}]|[\p{N}]|\b)|[\p{Lu}]?[\p{Ll}]+(?:'\p{Ll}+)?(?:[\p{N}]*)|'\p{Ll}+|[\p{Lu}]|[\p{N}]+/gu
   ) ?? ['']
 
-  return matches.map((x) => x.charAt(0).toUpperCase() + x.slice(1)).join(' ')
+  const format = (w: string) => {
+    if (w.startsWith("'") && w.length > 2) {
+      return `'${w[1].toUpperCase()}${w.slice(2)}`
+    }
+    return w.charAt(0).toUpperCase() + w.slice(1)
+  }
+
+  return words.reduce((acc, word, index) => {
+    const formatted = format(word)
+    if (index === 0) return formatted
+    if (word.startsWith("'")) return acc + formatted
+    return `${acc} ${formatted}`
+  }, '')
 }
 
 function inferLabel(fieldName: string) {
   return startCase(fieldName).replace(/Url/g, 'URL')
 }
 
-export { inferLabel }
+export { inferLabel, startCase }


### PR DESCRIPTION
## Summary
- update regex in infer-label
- cover accented characters in infer-label unit tests
- add example select with accented enum options
- run tests for new route

## Testing
- `npm run lint-fix`
- `npm run lint`
- `npm run tsc`
- `npm run test` *(fails: 2 failed tests)*