### PR TITLE
Refine startCase handling and add tests

### DIFF
--- a/packages/remix-forms/src/infer-label.test.ts
+++ b/packages/remix-forms/src/infer-label.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { inferLabel } from './infer-label'
+import { inferLabel, startCase } from './infer-label'
 
 describe('inferLabel', () => {
   it('capitalizes the field name', () => {
@@ -32,5 +32,31 @@ describe('inferLabel', () => {
   it('keeps accents when inferring labels', () => {
     expect(inferLabel('avião')).toBe('Avião')
     expect(inferLabel('ônibus')).toBe('Ônibus')
+  })
+})
+
+describe('startCase', () => {
+  it('handles camelCase with acronyms and numbers', () => {
+    expect(startCase('fooBarHTML42')).toBe('Foo Bar HTML 42')
+  })
+
+  it('handles words with apostrophes', () => {
+    expect(startCase("rock'n'roll")).toBe("Rock'n'Roll")
+  })
+
+  it('handles multiple apostrophes in camelCase', () => {
+    expect(startCase("can'tStopWon'tStop")).toBe("Can't Stop Won't Stop")
+  })
+
+  it('handles trailing numbers', () => {
+    expect(startCase('item42')).toBe('Item42')
+  })
+
+  it('splits camel cased acronyms', () => {
+    expect(startCase('XMLHttpRequest')).toBe('XML Http Request')
+  })
+
+  it('handles a leading apostrophe', () => {
+    expect(startCase("'tisTheSeason")).toBe("'Tis The Season")
   })
 })

--- a/packages/remix-forms/src/infer-label.ts
+++ b/packages/remix-forms/src/infer-label.ts
@@ -1,13 +1,25 @@
 function startCase(str: string): string {
-  const matches = str.match(
-    /[\p{Lu}]{2,}(?=[\p{Lu}][\p{Ll}]+[\p{N}]*|\b)|[\p{Lu}]?[\p{Ll}]+[\p{N}]*|[\p{Lu}]|[\p{N}]+/gu
+  const words = str.match(
+    /[\p{Lu}]{2,}(?=[\p{Lu}][\p{Ll}]|[\p{N}]|\b)|[\p{Lu}]?[\p{Ll}]+(?:'\p{Ll}+)?(?:[\p{N}]*)|'\p{Ll}+|[\p{Lu}]|[\p{N}]+/gu
   ) ?? ['']
 
-  return matches.map((x) => x.charAt(0).toUpperCase() + x.slice(1)).join(' ')
+  const format = (w: string) => {
+    if (w.startsWith("'") && w.length > 2) {
+      return `'${w[1].toUpperCase()}${w.slice(2)}`
+    }
+    return w.charAt(0).toUpperCase() + w.slice(1)
+  }
+
+  return words.reduce((acc, word, index) => {
+    const formatted = format(word)
+    if (index === 0) return formatted
+    if (word.startsWith("'")) return acc + formatted
+    return `${acc} ${formatted}`
+  }, '')
 }
 
 function inferLabel(fieldName: string) {
   return startCase(fieldName).replace(/Url/g, 'URL')
 }
 
-export { inferLabel }
+export { inferLabel, startCase }


### PR DESCRIPTION
## Summary
- improve `startCase` implementation to handle apostrophes and digits
- export `startCase` for internal tests
- verify various startCase scenarios
- test leading apostrophe cases

## Testing
- `npm run lint-fix`
- `npm run lint`
- `npm run tsc`
- `npm run test` *(fails: Playwright test timeout)*
