### PR TITLE
Add missing shapeInfo enum test

### DIFF
--- a/packages/remix-forms/src/shape-info.test.ts
+++ b/packages/remix-forms/src/shape-info.test.ts
@@ -65,4 +65,14 @@ describe('shapeInfo', () => {
       enumValues: ['a', 'b'],
     })
   })
+
+  it('handles enums with optional, nullable and default modifiers', () => {
+    const shape = z.enum(['x', 'y']).optional().nullable().default('x')
+    const info = shapeInfo(shape)
+    expect(info.typeName).toBe('ZodEnum')
+    expect(info.optional).toBe(true)
+    expect(info.nullable).toBe(true)
+    expect(info.enumValues).toEqual(['x', 'y'])
+    expect(info.getDefaultValue?.()).toBe('x')
+  })
 })


### PR DESCRIPTION
## Summary
- cover enum metadata through optional, nullable, and default wrappers

## Testing
- `npm run lint-fix`
- `npm run lint`
- `npm run tsc`
- `npm run test` *(fails: 2 playwright tests fail due to environment)*