### PR TITLE
Add missing boolean coercion and navigation tests

### DIFF
--- a/packages/remix-forms/src/coercions.test.ts
+++ b/packages/remix-forms/src/coercions.test.ts
@@ -59,6 +59,7 @@ describe('coerceValue', () => {
     expect(coerceValue('not a boolean', z.boolean())).toEqual(true)
     expect(coerceValue('false', z.boolean())).toEqual(true)
     expect(coerceValue('true', z.boolean())).toEqual(true)
+    expect(coerceValue(new File([], 'f'), z.boolean())).toEqual(true)
   })
 
   it('coerces booleans to false when value is empty', () => {

--- a/packages/remix-forms/src/schema-form.test.tsx
+++ b/packages/remix-forms/src/schema-form.test.tsx
@@ -17,7 +17,7 @@ vi.mock('react-router', () => {
   }
 })
 
-import { useActionData } from 'react-router'
+import { useActionData, useNavigation } from 'react-router'
 
 describe('SchemaForm', () => {
   it('renders provided values as form defaults', () => {
@@ -84,6 +84,18 @@ describe('SchemaForm', () => {
     )
 
     expect(html).toContain('Sending')
+  })
+
+  it('uses pendingButtonLabel when useNavigation state changes', () => {
+    const schema = z.object({ name: z.string() })
+    const navigation = vi.mocked(useNavigation)
+    navigation.mockReturnValueOnce({ state: 'submitting' } as never)
+
+    const html = renderToStaticMarkup(
+      <SchemaForm schema={schema} pendingButtonLabel="Wait" />
+    )
+
+    expect(html).toContain('Wait')
   })
 
   it('uses default values defined in the schema', () => {


### PR DESCRIPTION
## Notes
- Added unit test for coercing File values to boolean
- Added SchemaForm test verifying pending label when navigation state changes

## Testing
- `npm run lint-fix`
- `npm run lint`
- `npm run tsc`
- `npm run test` *(fails: Playwright tests require browser binaries)*