### PR TITLE
Fix flaky test by mocking router early

### DIFF
--- a/packages/remix-forms/src/hidden-errors.test.tsx
+++ b/packages/remix-forms/src/hidden-errors.test.tsx
@@ -1,8 +1,4 @@
-import type * as React from 'react'
-import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it, vi } from 'vitest'
-import * as z from 'zod'
-import { SchemaForm } from './schema-form'
 
 vi.mock('react-router', () => {
   return {
@@ -14,6 +10,11 @@ vi.mock('react-router', () => {
     useSubmit: () => () => {},
   }
 })
+
+import type * as React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import * as z from 'zod'
+import { SchemaForm } from './schema-form'
 
 describe('SchemaForm hidden field errors', () => {
   it('promotes hidden field errors to global errors', () => {

--- a/packages/remix-forms/src/schema-form.test.tsx
+++ b/packages/remix-forms/src/schema-form.test.tsx
@@ -1,10 +1,4 @@
-import * as React from 'react'
-import { renderToStaticMarkup } from 'react-dom/server'
-import type { Form as ReactRouterForm } from 'react-router'
 import { describe, expect, it, vi } from 'vitest'
-import * as z from 'zod'
-import { SchemaForm } from './schema-form'
-import type { RenderField } from './schema-form'
 
 vi.mock('react-router', () => {
   return {
@@ -16,6 +10,13 @@ vi.mock('react-router', () => {
     useSubmit: () => () => {},
   }
 })
+
+import * as React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import type { Form as ReactRouterForm } from 'react-router'
+import * as z from 'zod'
+import { SchemaForm } from './schema-form'
+import type { RenderField } from './schema-form'
 
 import { useActionData, useNavigation } from 'react-router'
 


### PR DESCRIPTION
## Summary
- ensure react-router is mocked before SchemaForm is imported in tests

## Testing
- `npm run lint-fix`
- `npm run lint`
- `npm run tsc`
- `npm run playwright:ci:install`
- `npm run test` *(fails: [chromium] › routes/examples/field-error.spec.ts:35:1 › With JS enabled)*