### PR TITLE
Split long e2e tests

### DIFF
--- a/apps/web/app/routes/examples/numbers-with-js.spec.ts
+++ b/apps/web/app/routes/examples/numbers-with-js.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, testWithoutJS } from 'tests/setup/tests'
+import { expect, test } from 'tests/setup/tests'
 
 const route = '/examples/schemas/numbers'
 
@@ -104,112 +104,6 @@ test('With JS enabled', async ({ example }) => {
 
   await button.click()
   await expect(button).toBeDisabled()
-
-  await example.expectData({
-    mandatory: 1,
-    nullable: null,
-    defaultRandom: expect.any(Number),
-    greaterThan: 6,
-    greaterThanOrEqualTo: 10,
-    lowerThan: 4,
-    lowerThanOrEqualTo: 10,
-    integer: 4,
-    optional: 5,
-  })
-})
-
-testWithoutJS('With JS disabled', async ({ example }) => {
-  const { button, page } = example
-  const mandatory = example.field('mandatory')
-  const optional = example.field('optional')
-  const nullable = example.field('nullable')
-  const greaterThan = example.field('greaterThan')
-  const greaterThanOrEqualTo = example.field('greaterThanOrEqualTo')
-  const lowerThan = example.field('lowerThan')
-  const lowerThanOrEqualTo = example.field('lowerThanOrEqualTo')
-  const integer = example.field('integer')
-
-  await page.goto(route)
-
-  // Server-side validation
-  await button.click()
-  await page.reload()
-
-  await example.expectError(mandatory, 'Expected number, received null')
-  await example.expectValid(optional)
-  await example.expectValid(nullable)
-
-  await example.expectError(greaterThan, 'Expected number, received null')
-  await example.expectError(
-    greaterThanOrEqualTo,
-    'Expected number, received null'
-  )
-  await example.expectError(lowerThan, 'Expected number, received null')
-  await example.expectError(
-    lowerThanOrEqualTo,
-    'Expected number, received null'
-  )
-  await example.expectError(integer, 'Expected number, received null')
-  await example.expectAutoFocus(mandatory)
-
-  // Test other errors
-  await greaterThan.input.fill('4')
-  await greaterThanOrEqualTo.input.fill('4')
-  await lowerThan.input.fill('11')
-  await lowerThanOrEqualTo.input.fill('11')
-  await button.click()
-  await page.reload()
-
-  await example.expectError(greaterThan, 'Number must be greater than 5')
-  await example.expectError(
-    greaterThanOrEqualTo,
-    'Number must be greater than or equal to 10'
-  )
-  await example.expectError(lowerThan, 'Number must be less than 5')
-  await example.expectError(
-    lowerThanOrEqualTo,
-    'Number must be less than or equal to 10'
-  )
-
-  // Make first field be valid, focus goes to the second field
-  await mandatory.input.fill('1')
-  await button.click()
-  await page.reload()
-  await example.expectValid(mandatory)
-  await example.expectAutoFocus(greaterThan)
-
-  await greaterThan.input.fill('6')
-  await button.click()
-  await page.reload()
-  await example.expectValid(greaterThan)
-  await example.expectAutoFocus(greaterThanOrEqualTo)
-
-  await greaterThanOrEqualTo.input.fill('10')
-  await button.click()
-  await page.reload()
-  await example.expectValid(greaterThanOrEqualTo)
-  await example.expectAutoFocus(lowerThan)
-
-  await lowerThan.input.fill('4')
-  await button.click()
-  await page.reload()
-  await example.expectValid(lowerThan)
-  await example.expectAutoFocus(lowerThanOrEqualTo)
-
-  await lowerThanOrEqualTo.input.fill('10')
-  await button.click()
-  await page.reload()
-  await example.expectValid(lowerThanOrEqualTo)
-  await example.expectAutoFocus(integer)
-
-  await integer.input.fill('4')
-
-  await optional.input.fill('5')
-
-  await button.click()
-  await page.reload()
-
-  await example.expectValid(integer)
 
   await example.expectData({
     mandatory: 1,

--- a/apps/web/app/routes/examples/numbers-without-js.spec.ts
+++ b/apps/web/app/routes/examples/numbers-without-js.spec.ts
@@ -1,0 +1,109 @@
+import { expect, testWithoutJS } from 'tests/setup/tests'
+
+const route = '/examples/schemas/numbers'
+
+testWithoutJS('With JS disabled', async ({ example }) => {
+  const { button, page } = example
+  const mandatory = example.field('mandatory')
+  const optional = example.field('optional')
+  const nullable = example.field('nullable')
+  const greaterThan = example.field('greaterThan')
+  const greaterThanOrEqualTo = example.field('greaterThanOrEqualTo')
+  const lowerThan = example.field('lowerThan')
+  const lowerThanOrEqualTo = example.field('lowerThanOrEqualTo')
+  const integer = example.field('integer')
+
+  await page.goto(route)
+
+  // Server-side validation
+  await button.click()
+  await page.reload()
+
+  await example.expectError(mandatory, 'Expected number, received null')
+  await example.expectValid(optional)
+  await example.expectValid(nullable)
+
+  await example.expectError(greaterThan, 'Expected number, received null')
+  await example.expectError(
+    greaterThanOrEqualTo,
+    'Expected number, received null'
+  )
+  await example.expectError(lowerThan, 'Expected number, received null')
+  await example.expectError(
+    lowerThanOrEqualTo,
+    'Expected number, received null'
+  )
+  await example.expectError(integer, 'Expected number, received null')
+  await example.expectAutoFocus(mandatory)
+
+  // Test other errors
+  await greaterThan.input.fill('4')
+  await greaterThanOrEqualTo.input.fill('4')
+  await lowerThan.input.fill('11')
+  await lowerThanOrEqualTo.input.fill('11')
+  await button.click()
+  await page.reload()
+
+  await example.expectError(greaterThan, 'Number must be greater than 5')
+  await example.expectError(
+    greaterThanOrEqualTo,
+    'Number must be greater than or equal to 10'
+  )
+  await example.expectError(lowerThan, 'Number must be less than 5')
+  await example.expectError(
+    lowerThanOrEqualTo,
+    'Number must be less than or equal to 10'
+  )
+
+  // Make first field be valid, focus goes to the second field
+  await mandatory.input.fill('1')
+  await button.click()
+  await page.reload()
+  await example.expectValid(mandatory)
+  await example.expectAutoFocus(greaterThan)
+
+  await greaterThan.input.fill('6')
+  await button.click()
+  await page.reload()
+  await example.expectValid(greaterThan)
+  await example.expectAutoFocus(greaterThanOrEqualTo)
+
+  await greaterThanOrEqualTo.input.fill('10')
+  await button.click()
+  await page.reload()
+  await example.expectValid(greaterThanOrEqualTo)
+  await example.expectAutoFocus(lowerThan)
+
+  await lowerThan.input.fill('4')
+  await button.click()
+  await page.reload()
+  await example.expectValid(lowerThan)
+  await example.expectAutoFocus(lowerThanOrEqualTo)
+
+  await lowerThanOrEqualTo.input.fill('10')
+  await button.click()
+  await page.reload()
+  await example.expectValid(lowerThanOrEqualTo)
+  await example.expectAutoFocus(integer)
+
+  await integer.input.fill('4')
+
+  await optional.input.fill('5')
+
+  await button.click()
+  await page.reload()
+
+  await example.expectValid(integer)
+
+  await example.expectData({
+    mandatory: 1,
+    nullable: null,
+    defaultRandom: expect.any(Number),
+    greaterThan: 6,
+    greaterThanOrEqualTo: 10,
+    lowerThan: 4,
+    lowerThanOrEqualTo: 10,
+    integer: 4,
+    optional: 5,
+  })
+})

--- a/apps/web/app/routes/examples/strings-with-js.spec.ts
+++ b/apps/web/app/routes/examples/strings-with-js.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, testWithoutJS } from 'tests/setup/tests'
+import { expect, test } from 'tests/setup/tests'
 
 const route = '/examples/schemas/strings'
 
@@ -85,90 +85,6 @@ test('With JS enabled', async ({ example }) => {
   await button.click()
   await example.expectValid(phoneNumber)
   await expect(button).toBeDisabled()
-
-  await example.expectData({
-    nonEmpty: 'John',
-    nullable: null,
-    default: 'Foo Bar',
-    minLength: 'abcde',
-    maxLength: 'abcde',
-    email: 'john@doe.com',
-    url: 'http://example.com',
-    phoneNumber: '5551234567',
-  })
-})
-
-testWithoutJS('With JS disabled', async ({ example }) => {
-  const { email, button, page } = example
-  const nonEmpty = example.field('nonEmpty')
-  const minLength = example.field('minLength')
-  const maxLength = example.field('maxLength')
-  const url = example.field('url')
-  const phoneNumber = example.field('phoneNumber')
-
-  await page.goto(route)
-
-  // Server-side validation
-  maxLength.input.fill('abcdefghijk')
-  await button.click()
-  await page.reload()
-
-  // Show field errors and focus on the first field
-  await example.expectError(
-    nonEmpty,
-    'String must contain at least 1 character(s)'
-  )
-  await example.expectError(
-    minLength,
-    'String must contain at least 5 character(s)'
-  )
-  await example.expectError(
-    maxLength,
-    'String must contain at most 10 character(s)'
-  )
-  await example.expectError(email, 'Invalid email')
-  await example.expectError(url, 'Invalid url')
-  await example.expectError(phoneNumber, 'Invalid phone number')
-  await example.expectAutoFocus(nonEmpty)
-
-  // Make first field be valid, focus goes to the second field
-  await nonEmpty.input.fill('John')
-  await button.click()
-  await page.reload()
-  await example.expectValid(nonEmpty)
-  await example.expectAutoFocus(minLength)
-
-  await minLength.input.fill('abcde')
-  await button.click()
-  await page.reload()
-  await example.expectValid(minLength)
-  await example.expectAutoFocus(maxLength)
-
-  await maxLength.input.fill('abcde')
-  await button.click()
-  await page.reload()
-  await example.expectValid(maxLength)
-  await example.expectAutoFocus(email)
-
-  await email.input.fill('john@doe.com')
-  await button.click()
-  await page.reload()
-  await example.expectValid(email)
-  await example.expectAutoFocus(url)
-
-  await url.input.fill('http://example.com')
-  await button.click()
-  await page.reload()
-  await example.expectValid(url)
-  await example.expectAutoFocus(phoneNumber)
-
-  // Make form be valid
-  await phoneNumber.input.fill('5551234567')
-
-  // Submit form
-  await button.click()
-  await page.reload()
-  await example.expectValid(phoneNumber)
 
   await example.expectData({
     nonEmpty: 'John',

--- a/apps/web/app/routes/examples/strings-without-js.spec.ts
+++ b/apps/web/app/routes/examples/strings-without-js.spec.ts
@@ -1,0 +1,87 @@
+import { testWithoutJS } from 'tests/setup/tests'
+
+const route = '/examples/schemas/strings'
+
+testWithoutJS('With JS disabled', async ({ example }) => {
+  const { email, button, page } = example
+  const nonEmpty = example.field('nonEmpty')
+  const minLength = example.field('minLength')
+  const maxLength = example.field('maxLength')
+  const url = example.field('url')
+  const phoneNumber = example.field('phoneNumber')
+
+  await page.goto(route)
+
+  // Server-side validation
+  maxLength.input.fill('abcdefghijk')
+  await button.click()
+  await page.reload()
+
+  // Show field errors and focus on the first field
+  await example.expectError(
+    nonEmpty,
+    'String must contain at least 1 character(s)'
+  )
+  await example.expectError(
+    minLength,
+    'String must contain at least 5 character(s)'
+  )
+  await example.expectError(
+    maxLength,
+    'String must contain at most 10 character(s)'
+  )
+  await example.expectError(email, 'Invalid email')
+  await example.expectError(url, 'Invalid url')
+  await example.expectError(phoneNumber, 'Invalid phone number')
+  await example.expectAutoFocus(nonEmpty)
+
+  // Make first field be valid, focus goes to the second field
+  await nonEmpty.input.fill('John')
+  await button.click()
+  await page.reload()
+  await example.expectValid(nonEmpty)
+  await example.expectAutoFocus(minLength)
+
+  await minLength.input.fill('abcde')
+  await button.click()
+  await page.reload()
+  await example.expectValid(minLength)
+  await example.expectAutoFocus(maxLength)
+
+  await maxLength.input.fill('abcde')
+  await button.click()
+  await page.reload()
+  await example.expectValid(maxLength)
+  await example.expectAutoFocus(email)
+
+  await email.input.fill('john@doe.com')
+  await button.click()
+  await page.reload()
+  await example.expectValid(email)
+  await example.expectAutoFocus(url)
+
+  await url.input.fill('http://example.com')
+  await button.click()
+  await page.reload()
+  await example.expectValid(url)
+  await example.expectAutoFocus(phoneNumber)
+
+  // Make form be valid
+  await phoneNumber.input.fill('5551234567')
+
+  // Submit form
+  await button.click()
+  await page.reload()
+  await example.expectValid(phoneNumber)
+
+  await example.expectData({
+    nonEmpty: 'John',
+    nullable: null,
+    default: 'Foo Bar',
+    minLength: 'abcde',
+    maxLength: 'abcde',
+    email: 'john@doe.com',
+    url: 'http://example.com',
+    phoneNumber: '5551234567',
+  })
+})


### PR DESCRIPTION
## Summary
- break up large numbers and strings e2e tests into JS and no-JS versions

## Testing
- `npm run lint-fix`
- `npm run lint`
- `npm run tsc`
- `npm run test`
