### PR TITLE
Split slow e2e tests

### DIFF
--- a/apps/web/app/routes/examples/async-validation-with-js.spec.ts
+++ b/apps/web/app/routes/examples/async-validation-with-js.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, testWithoutJS } from 'tests/setup/tests'
+import { expect, test } from 'tests/setup/tests'
 
 const route = '/examples/forms/async-validation'
 
@@ -58,55 +58,5 @@ test('With JS enabled', async ({ example }) => {
 
   // Submit form
   await button.click()
-  await example.expectData({ username: 'john', password: '123456' })
-})
-
-testWithoutJS('With JS disabled', async ({ example }) => {
-  const { password, button, page } = example
-  const username = example.field('username')
-
-  await page.goto(route)
-
-  // Server-side validation
-  await button.click()
-  await page.reload()
-
-  // Show field errors and focus on the first field
-  await example.expectError(
-    username,
-    'String must contain at least 1 character(s)'
-  )
-
-  await example.expectError(
-    password,
-    'String must contain at least 1 character(s)'
-  )
-
-  await example.expectAutoFocus(username)
-  await example.expectNoAutoFocus(password)
-
-  // Make first field be valid, focus goes to the second field
-  await username.input.fill('john')
-  await button.click()
-  await page.reload()
-  await example.expectValid(username)
-  await example.expectAutoFocus(password)
-  await example.expectNoAutoFocus(username)
-
-  // Make form be valid
-  await username.input.fill('foo')
-  await password.input.fill('123456')
-
-  // Submit form
-  await button.click()
-  await page.reload()
-
-  // Show field error
-  await example.expectError(username, 'Already taken')
-
-  // Submit valid form
-  await username.input.fill('john')
-  await button.click()
-  await page.reload()
   await example.expectData({ username: 'john', password: '123456' })
 })

--- a/apps/web/app/routes/examples/async-validation-without-js.spec.ts
+++ b/apps/web/app/routes/examples/async-validation-without-js.spec.ts
@@ -1,0 +1,53 @@
+import { testWithoutJS } from 'tests/setup/tests'
+
+const route = '/examples/forms/async-validation'
+
+testWithoutJS('With JS disabled', async ({ example }) => {
+  const { password, button, page } = example
+  const username = example.field('username')
+
+  await page.goto(route)
+
+  // Server-side validation
+  await button.click()
+  await page.reload()
+
+  // Show field errors and focus on the first field
+  await example.expectError(
+    username,
+    'String must contain at least 1 character(s)'
+  )
+
+  await example.expectError(
+    password,
+    'String must contain at least 1 character(s)'
+  )
+
+  await example.expectAutoFocus(username)
+  await example.expectNoAutoFocus(password)
+
+  // Make first field be valid, focus goes to the second field
+  await username.input.fill('john')
+  await button.click()
+  await page.reload()
+  await example.expectValid(username)
+  await example.expectAutoFocus(password)
+  await example.expectNoAutoFocus(username)
+
+  // Make form be valid
+  await username.input.fill('foo')
+  await password.input.fill('123456')
+
+  // Submit form
+  await button.click()
+  await page.reload()
+
+  // Show field error
+  await example.expectError(username, 'Already taken')
+
+  // Submit valid form
+  await username.input.fill('john')
+  await button.click()
+  await page.reload()
+  await example.expectData({ username: 'john', password: '123456' })
+})

--- a/apps/web/app/routes/examples/auto-generated-with-js.spec.ts
+++ b/apps/web/app/routes/examples/auto-generated-with-js.spec.ts
@@ -1,6 +1,6 @@
-import { expect, test, testWithoutJS } from 'tests/setup/tests'
+import { expect, test } from 'tests/setup/tests'
 
-const route = '/examples/forms/hidden-field'
+const route = '/examples/forms/auto-generated'
 
 test('With JS enabled', async ({ example }) => {
   const { firstName, email, button, page } = example
@@ -54,61 +54,6 @@ test('With JS enabled', async ({ example }) => {
   await button.click()
   await expect(button).toBeDisabled()
   await example.expectData({
-    csrfToken: 'abc123',
-    firstName: 'John',
-    email: 'john@doe.com',
-    howDidYouFindUs: 'google',
-  })
-})
-
-testWithoutJS('With JS disabled', async ({ example }) => {
-  const { firstName, email, button, page } = example
-  const howDidYouFindUs = example.field('howDidYouFindUs')
-
-  await page.goto(route)
-
-  // Server-side validation
-  await button.click()
-  await page.reload()
-
-  // Show field errors and focus on the first field
-  await example.expectError(
-    firstName,
-    'String must contain at least 1 character(s)'
-  )
-
-  await example.expectErrors(
-    email,
-    'String must contain at least 1 character(s)',
-    'Invalid email'
-  )
-
-  await example.expectAutoFocus(firstName)
-  await example.expectNoAutoFocus(email)
-
-  // Make first field be valid, focus goes to the second field
-  await firstName.input.fill('John')
-  await button.click()
-  await page.reload()
-  await example.expectValid(firstName)
-  await example.expectNoAutoFocus(firstName)
-  await example.expectAutoFocus(email)
-
-  // Try another invalid message
-  await email.input.fill('john')
-  await button.click()
-  await page.reload()
-  await example.expectError(email, 'Invalid email')
-
-  // Make form be valid and test selecting an option
-  await email.input.fill('john@doe.com')
-  await howDidYouFindUs.input.selectOption('google')
-
-  // Submit form
-  await button.click()
-  await page.reload()
-  await example.expectData({
-    csrfToken: 'abc123',
     firstName: 'John',
     email: 'john@doe.com',
     howDidYouFindUs: 'google',

--- a/apps/web/app/routes/examples/auto-generated-without-js.spec.ts
+++ b/apps/web/app/routes/examples/auto-generated-without-js.spec.ts
@@ -1,0 +1,56 @@
+import { testWithoutJS } from 'tests/setup/tests'
+
+const route = '/examples/forms/auto-generated'
+
+testWithoutJS('With JS disabled', async ({ example }) => {
+  const { firstName, email, button, page } = example
+  const howDidYouFindUs = example.field('howDidYouFindUs')
+
+  await page.goto(route)
+
+  // Server-side validation
+  await button.click()
+  await page.reload()
+
+  // Show field errors and focus on the first field
+  await example.expectError(
+    firstName,
+    'String must contain at least 1 character(s)'
+  )
+
+  await example.expectErrors(
+    email,
+    'String must contain at least 1 character(s)',
+    'Invalid email'
+  )
+
+  await example.expectAutoFocus(firstName)
+  await example.expectNoAutoFocus(email)
+
+  // Make first field be valid, focus goes to the second field
+  await firstName.input.fill('John')
+  await button.click()
+  await page.reload()
+  await example.expectValid(firstName)
+  await example.expectNoAutoFocus(firstName)
+  await example.expectAutoFocus(email)
+
+  // Try another invalid message
+  await email.input.fill('john')
+  await button.click()
+  await page.reload()
+  await example.expectError(email, 'Invalid email')
+
+  // Make form be valid and test selecting an option
+  await email.input.fill('john@doe.com')
+  await howDidYouFindUs.input.selectOption('google')
+
+  // Submit form
+  await button.click()
+  await page.reload()
+  await example.expectData({
+    firstName: 'John',
+    email: 'john@doe.com',
+    howDidYouFindUs: 'google',
+  })
+})

--- a/apps/web/app/routes/examples/field-layout-with-js.spec.ts
+++ b/apps/web/app/routes/examples/field-layout-with-js.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, testWithoutJS } from 'tests/setup/tests'
+import { expect, test } from 'tests/setup/tests'
 
 const route = '/examples/forms/field-layout'
 
@@ -58,67 +58,6 @@ test('With JS enabled', async ({ example }) => {
   await button.click()
   await example.expectValid(city)
   await expect(button).toBeDisabled()
-
-  await example.expectData({
-    street: 'Street',
-    number: '123',
-    extendedAddress: 'Extended address',
-    city: 'City',
-    state: 'Alaska',
-  })
-})
-
-testWithoutJS('With JS disabled', async ({ example }) => {
-  const { button, page } = example
-  const street = example.field('street')
-  const number = example.field('number')
-  const extendedAddress = example.field('extendedAddress')
-  const city = example.field('city')
-  const state = example.field('state')
-
-  await page.goto(route)
-  await example.expectAutoFocus(street)
-
-  // Server-side validation
-  await button.click()
-  await page.reload()
-
-  // Show field errors and focus on the first field
-  await example.expectError(
-    street,
-    'String must contain at least 1 character(s)'
-  )
-  await example.expectError(
-    number,
-    'String must contain at least 1 character(s)'
-  )
-
-  await example.expectValid(extendedAddress)
-  await example.expectError(city, 'String must contain at least 1 character(s)')
-  await example.expectAutoFocus(street)
-
-  // Make first field be valid, focus goes to the second field
-  await street.input.fill('Street')
-  await button.click()
-  await page.reload()
-  await example.expectValid(street)
-  await example.expectAutoFocus(number)
-
-  await number.input.fill('123')
-  await button.click()
-  await page.reload()
-  await example.expectValid(number)
-  await example.expectAutoFocus(city)
-
-  // Make form be valid
-  await extendedAddress.input.fill('Extended address')
-  await city.input.fill('City')
-  await state.input.selectOption('Alaska')
-
-  // Submit form
-  await button.click()
-  await page.reload()
-  await example.expectValid(city)
 
   await example.expectData({
     street: 'Street',

--- a/apps/web/app/routes/examples/field-layout-without-js.spec.ts
+++ b/apps/web/app/routes/examples/field-layout-without-js.spec.ts
@@ -1,0 +1,64 @@
+import { testWithoutJS } from 'tests/setup/tests'
+
+const route = '/examples/forms/field-layout'
+
+testWithoutJS('With JS disabled', async ({ example }) => {
+  const { button, page } = example
+  const street = example.field('street')
+  const number = example.field('number')
+  const extendedAddress = example.field('extendedAddress')
+  const city = example.field('city')
+  const state = example.field('state')
+
+  await page.goto(route)
+  await example.expectAutoFocus(street)
+
+  // Server-side validation
+  await button.click()
+  await page.reload()
+
+  // Show field errors and focus on the first field
+  await example.expectError(
+    street,
+    'String must contain at least 1 character(s)'
+  )
+  await example.expectError(
+    number,
+    'String must contain at least 1 character(s)'
+  )
+
+  await example.expectValid(extendedAddress)
+  await example.expectError(city, 'String must contain at least 1 character(s)')
+  await example.expectAutoFocus(street)
+
+  // Make first field be valid, focus goes to the second field
+  await street.input.fill('Street')
+  await button.click()
+  await page.reload()
+  await example.expectValid(street)
+  await example.expectAutoFocus(number)
+
+  await number.input.fill('123')
+  await button.click()
+  await page.reload()
+  await example.expectValid(number)
+  await example.expectAutoFocus(city)
+
+  // Make form be valid
+  await extendedAddress.input.fill('Extended address')
+  await city.input.fill('City')
+  await state.input.selectOption('Alaska')
+
+  // Submit form
+  await button.click()
+  await page.reload()
+  await example.expectValid(city)
+
+  await example.expectData({
+    street: 'Street',
+    number: '123',
+    extendedAddress: 'Extended address',
+    city: 'City',
+    state: 'Alaska',
+  })
+})

--- a/apps/web/app/routes/examples/global-error-with-js.spec.ts
+++ b/apps/web/app/routes/examples/global-error-with-js.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, testWithoutJS } from 'tests/setup/tests'
+import { expect, test } from 'tests/setup/tests'
 
 const route = '/examples/actions/global-error'
 
@@ -53,61 +53,5 @@ test('With JS enabled', async ({ example }) => {
   await password.input.fill('supersafe')
   await button.click()
   await example.expectNoGlobalError()
-  await example.expectData({ email: 'john@doe.com', password: 'supersafe' })
-})
-
-testWithoutJS('With JS disabled', async ({ example }) => {
-  const { email, password, button, page } = example
-
-  await page.goto(route)
-
-  // Server-side validation
-  await button.click()
-  await page.reload()
-
-  // Show field errors and focus on the first field
-  await example.expectErrors(
-    email,
-    'String must contain at least 1 character(s)',
-    'Invalid email'
-  )
-
-  await example.expectError(
-    password,
-    'String must contain at least 1 character(s)'
-  )
-
-  await example.expectAutoFocus(email)
-  await example.expectNoAutoFocus(password)
-
-  // Make first field be valid, focus goes to the second field
-  await email.input.fill('john@doe.com')
-  await button.click()
-  await page.reload()
-  await example.expectValid(email)
-  await example.expectAutoFocus(password)
-  await example.expectNoAutoFocus(email)
-
-  // Try another invalid message
-  await email.input.fill('john')
-  await button.click()
-  await page.reload()
-  await example.expectError(email, 'Invalid email')
-
-  // Make form be valid
-  await email.input.fill('john@doe.com')
-  await password.input.fill('123456')
-
-  // Submit form
-  await button.click()
-  await page.reload()
-
-  // Show global error
-  await example.expectGlobalError('Wrong email or password')
-
-  // Submit valid form
-  await password.input.fill('supersafe')
-  await button.click()
-  await page.reload()
   await example.expectData({ email: 'john@doe.com', password: 'supersafe' })
 })

--- a/apps/web/app/routes/examples/global-error-without-js.spec.ts
+++ b/apps/web/app/routes/examples/global-error-without-js.spec.ts
@@ -1,0 +1,59 @@
+import { testWithoutJS } from 'tests/setup/tests'
+
+const route = '/examples/actions/global-error'
+
+testWithoutJS('With JS disabled', async ({ example }) => {
+  const { email, password, button, page } = example
+
+  await page.goto(route)
+
+  // Server-side validation
+  await button.click()
+  await page.reload()
+
+  // Show field errors and focus on the first field
+  await example.expectErrors(
+    email,
+    'String must contain at least 1 character(s)',
+    'Invalid email'
+  )
+
+  await example.expectError(
+    password,
+    'String must contain at least 1 character(s)'
+  )
+
+  await example.expectAutoFocus(email)
+  await example.expectNoAutoFocus(password)
+
+  // Make first field be valid, focus goes to the second field
+  await email.input.fill('john@doe.com')
+  await button.click()
+  await page.reload()
+  await example.expectValid(email)
+  await example.expectAutoFocus(password)
+  await example.expectNoAutoFocus(email)
+
+  // Try another invalid message
+  await email.input.fill('john')
+  await button.click()
+  await page.reload()
+  await example.expectError(email, 'Invalid email')
+
+  // Make form be valid
+  await email.input.fill('john@doe.com')
+  await password.input.fill('123456')
+
+  // Submit form
+  await button.click()
+  await page.reload()
+
+  // Show global error
+  await example.expectGlobalError('Wrong email or password')
+
+  // Submit valid form
+  await password.input.fill('supersafe')
+  await button.click()
+  await page.reload()
+  await example.expectData({ email: 'john@doe.com', password: 'supersafe' })
+})

--- a/apps/web/app/routes/examples/hidden-field-with-js.spec.ts
+++ b/apps/web/app/routes/examples/hidden-field-with-js.spec.ts
@@ -1,6 +1,6 @@
-import { expect, test, testWithoutJS } from 'tests/setup/tests'
+import { expect, test } from 'tests/setup/tests'
 
-const route = '/examples/forms/auto-generated'
+const route = '/examples/forms/hidden-field'
 
 test('With JS enabled', async ({ example }) => {
   const { firstName, email, button, page } = example
@@ -54,59 +54,7 @@ test('With JS enabled', async ({ example }) => {
   await button.click()
   await expect(button).toBeDisabled()
   await example.expectData({
-    firstName: 'John',
-    email: 'john@doe.com',
-    howDidYouFindUs: 'google',
-  })
-})
-
-testWithoutJS('With JS disabled', async ({ example }) => {
-  const { firstName, email, button, page } = example
-  const howDidYouFindUs = example.field('howDidYouFindUs')
-
-  await page.goto(route)
-
-  // Server-side validation
-  await button.click()
-  await page.reload()
-
-  // Show field errors and focus on the first field
-  await example.expectError(
-    firstName,
-    'String must contain at least 1 character(s)'
-  )
-
-  await example.expectErrors(
-    email,
-    'String must contain at least 1 character(s)',
-    'Invalid email'
-  )
-
-  await example.expectAutoFocus(firstName)
-  await example.expectNoAutoFocus(email)
-
-  // Make first field be valid, focus goes to the second field
-  await firstName.input.fill('John')
-  await button.click()
-  await page.reload()
-  await example.expectValid(firstName)
-  await example.expectNoAutoFocus(firstName)
-  await example.expectAutoFocus(email)
-
-  // Try another invalid message
-  await email.input.fill('john')
-  await button.click()
-  await page.reload()
-  await example.expectError(email, 'Invalid email')
-
-  // Make form be valid and test selecting an option
-  await email.input.fill('john@doe.com')
-  await howDidYouFindUs.input.selectOption('google')
-
-  // Submit form
-  await button.click()
-  await page.reload()
-  await example.expectData({
+    csrfToken: 'abc123',
     firstName: 'John',
     email: 'john@doe.com',
     howDidYouFindUs: 'google',

--- a/apps/web/app/routes/examples/hidden-field-without-js.spec.ts
+++ b/apps/web/app/routes/examples/hidden-field-without-js.spec.ts
@@ -1,0 +1,57 @@
+import { testWithoutJS } from 'tests/setup/tests'
+
+const route = '/examples/forms/hidden-field'
+
+testWithoutJS('With JS disabled', async ({ example }) => {
+  const { firstName, email, button, page } = example
+  const howDidYouFindUs = example.field('howDidYouFindUs')
+
+  await page.goto(route)
+
+  // Server-side validation
+  await button.click()
+  await page.reload()
+
+  // Show field errors and focus on the first field
+  await example.expectError(
+    firstName,
+    'String must contain at least 1 character(s)'
+  )
+
+  await example.expectErrors(
+    email,
+    'String must contain at least 1 character(s)',
+    'Invalid email'
+  )
+
+  await example.expectAutoFocus(firstName)
+  await example.expectNoAutoFocus(email)
+
+  // Make first field be valid, focus goes to the second field
+  await firstName.input.fill('John')
+  await button.click()
+  await page.reload()
+  await example.expectValid(firstName)
+  await example.expectNoAutoFocus(firstName)
+  await example.expectAutoFocus(email)
+
+  // Try another invalid message
+  await email.input.fill('john')
+  await button.click()
+  await page.reload()
+  await example.expectError(email, 'Invalid email')
+
+  // Make form be valid and test selecting an option
+  await email.input.fill('john@doe.com')
+  await howDidYouFindUs.input.selectOption('google')
+
+  // Submit form
+  await button.click()
+  await page.reload()
+  await example.expectData({
+    csrfToken: 'abc123',
+    firstName: 'John',
+    email: 'john@doe.com',
+    howDidYouFindUs: 'google',
+  })
+})


### PR DESCRIPTION
## Summary
- split several end-to-end test files into separate JS and no-JS variants to speed up parallel Playwright runs

## Testing
- `npm run lint-fix`
- `npm run lint`
- `npm run tsc`
- `npm run test` *(fails: run aborted due to environment limits)*