### PR TITLE
Add getZodDef helper

### DIFF
--- a/packages/remix-forms/src/get-zod-def.ts
+++ b/packages/remix-forms/src/get-zod-def.ts
@@ -1,0 +1,9 @@
+import type { z } from 'zod/v4'
+
+function getZodDef(schema: z.ZodTypeAny) {
+  // biome-ignore lint/suspicious/noExplicitAny: accessing zod internals
+  const anySchema: any = schema
+  return anySchema._zod?.def ?? anySchema._def
+}
+
+export { getZodDef }

--- a/packages/remix-forms/src/prelude.ts
+++ b/packages/remix-forms/src/prelude.ts
@@ -1,4 +1,5 @@
 import type { z } from 'zod/v4'
+import { getZodDef } from './get-zod-def'
 
 /**
  * Zod schema accepted by remix-forms components and utilities.
@@ -44,7 +45,7 @@ function objectFromSchema<Schema extends FormSchema>(
 ): ObjectFromSchema<Schema> {
   return 'shape' in schema
     ? (schema as ObjectFromSchema<Schema>)
-    : objectFromSchema(schema._def.schema)
+    : objectFromSchema(getZodDef(schema).schema)
 }
 
 function mapObject<T extends Record<string, V>, V, NewValue>(

--- a/packages/remix-forms/src/shape-info.ts
+++ b/packages/remix-forms/src/shape-info.ts
@@ -1,4 +1,5 @@
 import type { ZodTypeAny } from 'zod/v4'
+import { getZodDef } from './get-zod-def'
 
 type ZodTypeName =
   | 'ZodString'
@@ -26,11 +27,12 @@ function shapeInfo(
     return { typeName: null, optional, nullable, getDefaultValue, enumValues }
   }
 
-  const typeName = shape._def.typeName
+  const def = getZodDef(shape)
+  const typeName = def.typeName
 
   if (typeName === 'ZodEffects') {
     return shapeInfo(
-      shape._def.schema,
+      def.schema,
       optional,
       nullable,
       getDefaultValue,
@@ -39,31 +41,19 @@ function shapeInfo(
   }
 
   if (typeName === 'ZodOptional') {
-    return shapeInfo(
-      shape._def.innerType,
-      true,
-      nullable,
-      getDefaultValue,
-      enumValues
-    )
+    return shapeInfo(def.innerType, true, nullable, getDefaultValue, enumValues)
   }
 
   if (typeName === 'ZodNullable') {
-    return shapeInfo(
-      shape._def.innerType,
-      optional,
-      true,
-      getDefaultValue,
-      enumValues
-    )
+    return shapeInfo(def.innerType, optional, true, getDefaultValue, enumValues)
   }
 
   if (typeName === 'ZodDefault') {
     return shapeInfo(
-      shape._def.innerType,
+      def.innerType,
       optional,
       nullable,
-      shape._def.defaultValue,
+      def.defaultValue,
       enumValues
     )
   }
@@ -74,7 +64,7 @@ function shapeInfo(
       optional,
       nullable,
       getDefaultValue,
-      enumValues: shape._def.values,
+      enumValues: def.values,
     }
   }
 


### PR DESCRIPTION
## Summary
- add `getZodDef` helper for accessing the zod definition
- use `getZodDef` in `shape-info` and `prelude`

## Testing
- `npm run lint-fix`
- `npm run lint`
- `npm run tsc` *(fails: error occurred in dts build)*
- `npm run test` *(fails: tests fail to run)*