### PR TITLE
Add unwrapSchema utility

### DIFF
--- a/packages/remix-forms/src/prelude.ts
+++ b/packages/remix-forms/src/prelude.ts
@@ -1,4 +1,5 @@
 import type { z } from 'zod/v4'
+import { unwrapSchema } from './unwrap-schema'
 
 /**
  * Zod schema accepted by remix-forms components and utilities.
@@ -42,9 +43,7 @@ type KeysOfStrings<T extends object> = {
 function objectFromSchema<Schema extends FormSchema>(
   schema: Schema
 ): ObjectFromSchema<Schema> {
-  return 'shape' in schema
-    ? (schema as ObjectFromSchema<Schema>)
-    : objectFromSchema(schema._def.schema)
+  return unwrapSchema(schema) as ObjectFromSchema<Schema>
 }
 
 function mapObject<T extends Record<string, V>, V, NewValue>(

--- a/packages/remix-forms/src/shape-info.ts
+++ b/packages/remix-forms/src/shape-info.ts
@@ -1,4 +1,5 @@
 import type { ZodTypeAny } from 'zod/v4'
+import { unwrapSchema } from './unwrap-schema'
 
 type ZodTypeName =
   | 'ZodString'
@@ -31,6 +32,17 @@ function shapeInfo(
   if (typeName === 'ZodEffects') {
     return shapeInfo(
       shape._def.schema,
+      optional,
+      nullable,
+      getDefaultValue,
+      enumValues
+    )
+  }
+
+  if (typeName === 'ZodPipe') {
+    const input = unwrapSchema(shape._def.in)
+    return shapeInfo(
+      input._def.typeName === 'ZodTransform' ? shape._def.out : shape._def.in,
       optional,
       nullable,
       getDefaultValue,

--- a/packages/remix-forms/src/unwrap-schema.ts
+++ b/packages/remix-forms/src/unwrap-schema.ts
@@ -1,0 +1,39 @@
+import type { ZodTypeAny } from 'zod/v4'
+
+function unwrapSchema<T extends ZodTypeAny>(schema: T): ZodTypeAny {
+  let current: ZodTypeAny = schema
+
+  while (current) {
+    const { typeName } = current._def
+
+    if (
+      typeName === 'ZodOptional' ||
+      typeName === 'ZodNullable' ||
+      typeName === 'ZodDefault'
+    ) {
+      current = current._def.innerType
+      continue
+    }
+
+    if (typeName === 'ZodEffects') {
+      current = current._def.schema
+      continue
+    }
+
+    if (typeName === 'ZodPipe') {
+      const inSchema = unwrapSchema(current._def.in)
+      if (inSchema._def.typeName === 'ZodTransform') {
+        current = current._def.out
+      } else {
+        current = current._def.in
+      }
+      continue
+    }
+
+    break
+  }
+
+  return current
+}
+
+export { unwrapSchema }


### PR DESCRIPTION
## Summary
- add `unwrapSchema` helper to peel off Zod wrappers
- use the helper in `shapeInfo` and `objectFromSchema`

## Testing
- `npm run lint-fix`
- `npm run lint`
- `npm run tsc` *(fails: SomeZodObject missing in zod/v4)*
- `npm run test` *(fails: vitest errors)*