### PR TITLE
Update Zod requirement

### DIFF
--- a/packages/remix-forms/README.md
+++ b/packages/remix-forms/README.md
@@ -2,4 +2,6 @@
 
 Documentation at [remix-forms.seasoned.cc](https://remix-forms.seasoned.cc).
 
+Requires **Zod** version 3.25 or later.
+
 Source code at [https://github.com/seasonedcc/remix-forms](https://github.com/seasonedcc/remix-forms).

--- a/packages/remix-forms/package.json
+++ b/packages/remix-forms/package.json
@@ -36,7 +36,7 @@
     "react": ">=16.8",
     "react-hook-form": ">=7.27",
     "react-router": ">=7",
-    "zod": ">=3.12"
+    "zod": ">=3.25"
   },
   "devDependencies": {
     "@types/react": ">=16.8",


### PR DESCRIPTION
## Summary
- relax peer dependency to support Zod 3.25+
- mention the minimum Zod version in the package README

## Testing
- `npm run lint-fix`
- `npm run lint`
- `npm run tsc` *(fails: error occurred in dts build)*
- `npm run test` *(fails: vitest run error)*