### PR TITLE
Refactor schema internals away from zod specifics

### DIFF
--- a/packages/remix-forms/src/adapters/adapter.ts
+++ b/packages/remix-forms/src/adapters/adapter.ts
@@ -9,8 +9,10 @@ import type { Resolver } from 'react-hook-form'
 /**
  * Definition describing a single field in a schema.
  */
+type FieldTypeName = 'string' | 'number' | 'boolean' | 'date' | 'enum'
+
 type FieldInfo = {
-  typeName: string | null
+  typeName: FieldTypeName | null
   optional: boolean
   nullable: boolean
   getDefaultValue?: () => unknown
@@ -41,4 +43,4 @@ interface SchemaAdapter {
   objectFromSchema(schema: unknown): { shape: Record<string, unknown> }
 }
 
-export type { SchemaAdapter, FieldInfo }
+export type { SchemaAdapter, FieldInfo, FieldTypeName }

--- a/packages/remix-forms/src/adapters/zod3.ts
+++ b/packages/remix-forms/src/adapters/zod3.ts
@@ -1,6 +1,8 @@
 import { zodResolver } from '@hookform/resolvers/zod'
-import type { SomeZodObject, ZodTypeAny } from 'zod'
-import type { FieldInfo, SchemaAdapter } from './adapter'
+import type * as z from 'zod'
+import type { FieldInfo, FieldTypeName, SchemaAdapter } from './adapter'
+type SomeZodObject = z.SomeZodObject
+type ZodTypeAny = z.ZodTypeAny
 
 type ZodTypeName =
   | 'ZodString'
@@ -20,14 +22,22 @@ function shapeInfo(
     return { typeName: null, optional, nullable, getDefaultValue, enumValues }
   }
 
-  const typeName = shape._def.typeName as
+  const zodTypeName = shape._def.typeName as
     | ZodTypeName
     | 'ZodEffects'
     | 'ZodOptional'
     | 'ZodNullable'
     | 'ZodDefault'
+  const typeNameMap: Record<ZodTypeName, FieldTypeName> = {
+    ZodString: 'string',
+    ZodNumber: 'number',
+    ZodBoolean: 'boolean',
+    ZodDate: 'date',
+    ZodEnum: 'enum',
+  }
+  const typeName = typeNameMap[zodTypeName as ZodTypeName] ?? null
 
-  if (typeName === 'ZodEffects') {
+  if (zodTypeName === 'ZodEffects') {
     return shapeInfo(
       shape._def.schema,
       optional,
@@ -37,7 +47,7 @@ function shapeInfo(
     )
   }
 
-  if (typeName === 'ZodOptional') {
+  if (zodTypeName === 'ZodOptional') {
     return shapeInfo(
       shape._def.innerType,
       true,
@@ -47,7 +57,7 @@ function shapeInfo(
     )
   }
 
-  if (typeName === 'ZodNullable') {
+  if (zodTypeName === 'ZodNullable') {
     return shapeInfo(
       shape._def.innerType,
       optional,
@@ -57,7 +67,7 @@ function shapeInfo(
     )
   }
 
-  if (typeName === 'ZodDefault') {
+  if (zodTypeName === 'ZodDefault') {
     return shapeInfo(
       shape._def.innerType,
       optional,
@@ -67,7 +77,7 @@ function shapeInfo(
     )
   }
 
-  if (typeName === 'ZodEnum') {
+  if (zodTypeName === 'ZodEnum') {
     return {
       typeName,
       optional,
@@ -105,4 +115,4 @@ const zod3Adapter: SchemaAdapter = {
 }
 
 export { zod3Adapter }
-export type { ZodTypeName }
+export type { ZodTypeName, SomeZodObject, ZodTypeAny, z }

--- a/packages/remix-forms/src/coerce-to-form.ts
+++ b/packages/remix-forms/src/coerce-to-form.ts
@@ -10,19 +10,15 @@ import { parseDate } from './prelude'
 
 function coerceToForm(value: unknown, info: FieldInfo) {
   const { typeName } = info
-  if (typeName === 'ZodBoolean') {
+  if (typeName === 'boolean') {
     return Boolean(value) ?? false
   }
 
-  if (typeName === 'ZodDate') {
+  if (typeName === 'date') {
     return parseDate(value as Date | undefined)
   }
 
-  if (
-    typeName === 'ZodEnum' ||
-    typeName === 'ZodString' ||
-    typeName === 'ZodNumber'
-  ) {
+  if (typeName === 'enum' || typeName === 'string' || typeName === 'number') {
     return String(value ?? '')
   }
 

--- a/packages/remix-forms/src/coercions.ts
+++ b/packages/remix-forms/src/coercions.ts
@@ -1,5 +1,4 @@
 import type { QueryStringRecord } from 'composable-functions'
-import type { ZodTypeAny } from 'zod'
 import type { SchemaAdapter } from './adapters/adapter'
 import { zod3Adapter } from './adapters/zod3'
 
@@ -37,24 +36,24 @@ const coerceDate = makeCoercion((value) => {
 
 function coerceValue(
   value: Value,
-  shape?: ZodTypeAny,
+  shape?: unknown,
   adapter: SchemaAdapter = zod3Adapter
 ) {
   const { typeName, optional, nullable } = adapter.getFieldInfo(shape)
 
-  if (typeName === 'ZodBoolean') {
+  if (typeName === 'boolean') {
     return coerceBoolean({ value, optional, nullable })
   }
 
-  if (typeName === 'ZodNumber') {
+  if (typeName === 'number') {
     return coerceNumber({ value, optional, nullable })
   }
 
-  if (typeName === 'ZodDate') {
+  if (typeName === 'date') {
     return coerceDate({ value, optional, nullable })
   }
 
-  if (typeName === 'ZodString' || typeName === 'ZodEnum') {
+  if (typeName === 'string' || typeName === 'enum') {
     return coerceString({ value, optional, nullable })
   }
 

--- a/packages/remix-forms/src/create-field.tsx
+++ b/packages/remix-forms/src/create-field.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import type { UseFormRegister, UseFormRegisterReturn } from 'react-hook-form'
-import type { SomeZodObject, z } from 'zod'
 import type { SchemaAdapter } from './adapters/adapter'
+import type { SomeZodObject, z } from './adapters/zod3'
 import { zod3Adapter } from './adapters/zod3'
 import { findElement, findParent, mapChildren } from './children-traversal'
 import { coerceValue } from './coercions'

--- a/packages/remix-forms/src/default-render-field.test.tsx
+++ b/packages/remix-forms/src/default-render-field.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { describe, expect, it } from 'vitest'
-import type * as z from 'zod'
+import type { z } from './adapters/zod3'
 import type { FieldComponent } from './create-field'
 import { defaultRenderField } from './default-render-field'
 

--- a/packages/remix-forms/src/default-render-field.tsx
+++ b/packages/remix-forms/src/default-render-field.tsx
@@ -1,4 +1,4 @@
-import type { SomeZodObject } from 'zod'
+import type { SomeZodObject } from './adapters/zod3'
 import type { RenderFieldProps } from './schema-form'
 
 function defaultRenderField<Schema extends SomeZodObject>({

--- a/packages/remix-forms/src/mutations.ts
+++ b/packages/remix-forms/src/mutations.ts
@@ -5,7 +5,7 @@ import {
   isInputError,
 } from 'composable-functions'
 import { data, redirect } from 'react-router'
-import type { z } from 'zod'
+import type { z } from './adapters/zod3'
 import { coerceValue } from './coercions'
 import type { FormSchema } from './prelude'
 import { objectFromSchema } from './prelude'

--- a/packages/remix-forms/src/prelude.ts
+++ b/packages/remix-forms/src/prelude.ts
@@ -1,5 +1,5 @@
-import type { z } from 'zod'
 import type { SchemaAdapter } from './adapters/adapter'
+import type { z } from './adapters/zod3'
 import { zod3Adapter } from './adapters/zod3'
 
 /**

--- a/packages/remix-forms/src/schema-form.tsx
+++ b/packages/remix-forms/src/schema-form.tsx
@@ -15,10 +15,9 @@ import {
   useNavigation,
   useSubmit,
 } from 'react-router'
-import type { SomeZodObject, TypeOf, ZodTypeAny, z } from 'zod'
-import type { SchemaAdapter } from './adapters/adapter'
+import type { FieldTypeName, SchemaAdapter } from './adapters/adapter'
+import type { SomeZodObject, ZodTypeAny, z } from './adapters/zod3'
 import { zod3Adapter } from './adapters/zod3'
-import type { ZodTypeName } from './adapters/zod3'
 import { mapChildren, reduceElements } from './children-traversal'
 import { coerceToForm } from './coerce-to-form'
 import type {
@@ -170,12 +169,12 @@ type SchemaFormProps<Schema extends FormSchema> = ComponentMappings & {
   adapter?: SchemaAdapter
 } & Omit<ReactRouterFormProps, 'children' | 'autoFocus'>
 
-const fieldTypes: Record<ZodTypeName, FieldType> = {
-  ZodString: 'string',
-  ZodNumber: 'number',
-  ZodBoolean: 'boolean',
-  ZodDate: 'date',
-  ZodEnum: 'string',
+const fieldTypes: Record<FieldTypeName, FieldType> = {
+  string: 'string',
+  number: 'number',
+  boolean: 'boolean',
+  date: 'date',
+  enum: 'string',
 }
 /**
 
@@ -307,7 +306,7 @@ function SchemaForm<Schema extends FormSchema>({
 
   const schemaShape = objectFromSchema(schema, adapter).shape
   const defaultValues = mapObject(schemaShape, (key, fieldShape) => {
-    const info = adapter.getFieldInfo(fieldShape as z.ZodTypeAny)
+    const info = adapter.getFieldInfo(fieldShape)
     const defaultValue = coerceToForm(
       values[key] ?? info?.getDefaultValue?.(),
       info
@@ -419,7 +418,7 @@ function SchemaForm<Schema extends FormSchema>({
 
     return {
       shape,
-      fieldType: typeName ? fieldTypes[typeName as ZodTypeName] : 'string',
+      fieldType: typeName ? fieldTypes[typeName] : 'string',
       type: inputTypes?.[key],
       name: key,
       required,
@@ -595,7 +594,7 @@ function SchemaForm<Schema extends FormSchema>({
 
   React.useEffect(() => {
     Object.keys(errors).forEach((key) => {
-      form.setError(key as Path<TypeOf<Schema>>, {
+      form.setError(key as Path<z.TypeOf<Schema>>, {
         type: 'custom',
         message: (errors[key] ?? []).join(', '),
       })

--- a/packages/remix-forms/src/zod3-adapter.test.ts
+++ b/packages/remix-forms/src/zod3-adapter.test.ts
@@ -15,7 +15,7 @@ describe('zod3Adapter.getFieldInfo', () => {
 
   it('extracts info from primitive shapes', () => {
     expect(zod3Adapter.getFieldInfo(z.string())).toEqual({
-      typeName: 'ZodString',
+      typeName: 'string',
       optional: false,
       nullable: false,
       getDefaultValue: undefined,
@@ -26,7 +26,7 @@ describe('zod3Adapter.getFieldInfo', () => {
   it('marks optional and nullable shapes correctly', () => {
     const info = zod3Adapter.getFieldInfo(z.number().optional().nullable())
     expect(info).toEqual({
-      typeName: 'ZodNumber',
+      typeName: 'number',
       optional: true,
       nullable: true,
       getDefaultValue: undefined,
@@ -36,7 +36,7 @@ describe('zod3Adapter.getFieldInfo', () => {
 
   it('collects default value getter', () => {
     const info = zod3Adapter.getFieldInfo(z.string().default('foo'))
-    expect(info.typeName).toBe('ZodString')
+    expect(info.typeName).toBe('string')
     expect(typeof info.getDefaultValue).toBe('function')
     expect(info.getDefaultValue?.()).toBe('foo')
   })
@@ -49,7 +49,7 @@ describe('zod3Adapter.getFieldInfo', () => {
       .nullable()
       .transform((v) => v)
     const info = zod3Adapter.getFieldInfo(shape)
-    expect(info.typeName).toBe('ZodString')
+    expect(info.typeName).toBe('string')
     expect(info.optional).toBe(true)
     expect(info.nullable).toBe(true)
     expect(info.getDefaultValue?.()).toBe('bar')
@@ -58,7 +58,7 @@ describe('zod3Adapter.getFieldInfo', () => {
   it('returns enum values', () => {
     const info = zod3Adapter.getFieldInfo(z.enum(['a', 'b']))
     expect(info).toEqual({
-      typeName: 'ZodEnum',
+      typeName: 'enum',
       optional: false,
       nullable: false,
       getDefaultValue: undefined,
@@ -69,7 +69,7 @@ describe('zod3Adapter.getFieldInfo', () => {
   it('handles enums with optional, nullable and default modifiers', () => {
     const shape = z.enum(['x', 'y']).optional().nullable().default('x')
     const info = zod3Adapter.getFieldInfo(shape)
-    expect(info.typeName).toBe('ZodEnum')
+    expect(info.typeName).toBe('enum')
     expect(info.optional).toBe(true)
     expect(info.nullable).toBe(true)
     expect(info.enumValues).toEqual(['x', 'y'])


### PR DESCRIPTION
## Summary
- allow adapters to report standardized field type names
- map zod internals to the new names in the zod3 adapter
- update coercion utilities to use the generic names
- rely on adapter exports instead of direct `zod` imports
- adjust tests for the new adapter output

## Testing
- `npm run lint-fix`
- `npm run lint`
- `npm run tsc`
- `npm run test`
